### PR TITLE
Enable Google Calendar OAuth in server/Docker mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,19 @@
 # Copy this file to .env and replace placeholder values for your local machine.
 
+# The public URL of your server deployment (used for OAuth redirect URIs).
+# Leave blank for local/desktop use (defaults to http://localhost:PORT).
+# Example: https://bulletin.yourchurch.org
+APP_URL=
+
 # Planning Center API credentials used by the server-side proxy.
 PCO_APP_ID=your-planning-center-app-id
 PCO_SECRET=your-planning-center-secret
+
+# Google Calendar OAuth credentials (for Settings > Connect Google Calendar).
+# Create a project at https://console.cloud.google.com, enable the Calendar API,
+# and add APP_URL/oauth/google/callback as an authorized redirect URI.
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
 
 # Optional: one or more calendar feed URLs.
 # You can use a JSON array or a comma/newline-separated list.

--- a/server.py
+++ b/server.py
@@ -832,10 +832,11 @@ class Handler(http.server.SimpleHTTPRequestHandler):
     def _handle_google_oauth_start(self):
         client_id = os.environ.get('GOOGLE_CLIENT_ID', '').strip()
         if not client_id:
-            self._send_json({'error': 'Google OAuth credentials not configured in desktop build.'}, 503)
+            self._send_json({'error': 'Google OAuth credentials not configured. Set GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET in .env.'}, 503)
             return
         port = self.server.server_address[1]
-        redirect_uri = f'http://localhost:{port}/oauth/google/callback'
+        app_url = os.environ.get('APP_URL', '').strip().rstrip('/')
+        redirect_uri = f'{app_url}/oauth/google/callback' if app_url else f'http://localhost:{port}/oauth/google/callback'
         params = urllib.parse.urlencode({
             'client_id':     client_id,
             'redirect_uri':  redirect_uri,
@@ -861,7 +862,8 @@ class Handler(http.server.SimpleHTTPRequestHandler):
         client_id     = os.environ.get('GOOGLE_CLIENT_ID',     '').strip()
         client_secret = os.environ.get('GOOGLE_CLIENT_SECRET', '').strip()
         port          = self.server.server_address[1]
-        redirect_uri  = f'http://localhost:{port}/oauth/google/callback'
+        app_url       = os.environ.get('APP_URL', '').strip().rstrip('/')
+        redirect_uri  = f'{app_url}/oauth/google/callback' if app_url else f'http://localhost:{port}/oauth/google/callback'
 
         try:
             token_data = urllib.parse.urlencode({


### PR DESCRIPTION
## Summary
- Adds `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` support in server/Docker mode
- Adds `APP_URL` env var so the OAuth redirect URI works on hosted deployments (not just localhost)
- Updates `.env.example` with Google OAuth and `APP_URL` entries with setup instructions

## How to use
1. Add `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, and `APP_URL` to your `.env`
2. In Google Cloud Console, add `APP_URL/oauth/google/callback` as an authorized redirect URI
3. The **Connect Google Calendar** button in Settings will now work on the server deployment

## Test plan
- [ ] Set `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET` in `.env` and click Connect Google Calendar in Settings
- [ ] Confirm OAuth redirect lands on correct callback URL
- [ ] Confirm calendar list loads and selection saves correctly
- [ ] Confirm iCal fallback still works when Google creds are not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)