### PR TITLE
Add nginx HTTPS reverse proxy for Tailscale deployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,23 @@ services:
     build: .
     env_file:
       - .env
-    ports:
-      - "8080:8080"
+    # No longer exposed directly — nginx handles inbound traffic
+    expose:
+      - "8080"
     volumes:
       # Persists local working data outside the image
       - ./data:/app/data
+    restart: unless-stopped
+
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - /etc/ssl/vcrcvault.tail97af2d.ts.net.crt:/etc/ssl/certs/vcrcvault.tail97af2d.ts.net.crt:ro
+      - /etc/ssl/vcrcvault.tail97af2d.ts.net.key:/etc/ssl/private/vcrcvault.tail97af2d.ts.net.key:ro
+    depends_on:
+      - worship-booklet
     restart: unless-stopped

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,25 @@
+server {
+    listen 443 ssl;
+    server_name vcrcvault.tail97af2d.ts.net;
+
+    ssl_certificate     /etc/ssl/certs/vcrcvault.tail97af2d.ts.net.crt;
+    ssl_certificate_key /etc/ssl/private/vcrcvault.tail97af2d.ts.net.key;
+
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_ciphers         HIGH:!aNULL:!MD5;
+
+    location / {
+        proxy_pass         http://worship-booklet:8080;
+        proxy_set_header   Host $host;
+        proxy_set_header   X-Real-IP $remote_addr;
+        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+}
+
+# Redirect HTTP to HTTPS
+server {
+    listen 80;
+    server_name vcrcvault.tail97af2d.ts.net;
+    return 301 https://$host$request_uri;
+}


### PR DESCRIPTION
## Summary
- Adds an nginx container to docker-compose that handles HTTPS/TLS termination
- Uses the Tailscale-issued cert at `/etc/ssl/` on the host server
- App container is no longer directly exposed — all traffic goes through nginx on ports 80/443
- HTTP automatically redirects to HTTPS

## Setup on server
Set `APP_URL=https://vcrcvault.tail97af2d.ts.net` in `.env`, then:
```bash
docker compose up --build -d
```

## Test plan
- [ ] `https://vcrcvault.tail97af2d.ts.net` loads the app over HTTPS
- [ ] `http://vcrcvault.tail97af2d.ts.net` redirects to HTTPS
- [ ] Google OAuth callback works with the new `APP_URL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)