### PR TITLE
Fix bug batch: security, announcement toolbar, conflict banner, clipboard, ProPresenter import, PDF export

### DIFF
--- a/server.py
+++ b/server.py
@@ -560,6 +560,11 @@ class Handler(http.server.SimpleHTTPRequestHandler):
     def do_GET(self):
         path = self.path.split("?")[0]
 
+        # Block direct access to raw data files — always serve via /api/* endpoints
+        if path.startswith("/data/"):
+            self._send_json({"error": "Forbidden"}, 403)
+            return
+
         if path == "/" or path == "/worship-booklet.html":
             try:
                 content = (BASE_DIR / "worship-booklet.html").read_bytes()

--- a/worship-booklet.html
+++ b/worship-booklet.html
@@ -2190,6 +2190,18 @@
 
     </div>
   </div>
+
+  <!-- Paste fallback dialog (shown when clipboard API is unavailable or denied) -->
+  <dialog id="sdb-paste-dialog" style="border:1px solid #ccc;border-radius:8px;padding:1.2rem;max-width:480px;width:90%;">
+    <h3 style="margin:0 0 0.5rem;">Paste Song Lyrics</h3>
+    <p style="font-size:0.85rem;color:#555;margin:0 0 0.6rem;">Clipboard access was denied or unavailable. Paste your copied text below:</p>
+    <textarea id="sdb-paste-fallback-ta" rows="10" style="width:100%;box-sizing:border-box;font-family:inherit;font-size:0.9rem;" placeholder="Paste lyrics here (Ctrl+V / Cmd+V)…"></textarea>
+    <div style="display:flex;gap:0.5rem;margin-top:0.6rem;justify-content:flex-end;">
+      <button type="button" class="btn-sm" id="sdb-paste-dialog-cancel">Cancel</button>
+      <button type="button" class="btn-sm btn-sm-primary" id="sdb-paste-dialog-ok">Import</button>
+    </div>
+  </dialog>
+
 </div><!-- #page-songdb -->
 
 <!-- ═══ PAGE: Settings ═══════════════════════════════════════════════════════ -->
@@ -3272,6 +3284,7 @@ function annRender() {
     toolbar.className = 'ann-card-toolbar';
 
     const boldBtn = document.createElement('button');
+    boldBtn.type = 'button';
     boldBtn.className = 'ann-fmt-btn ann-fmt-bold';
     boldBtn.title = 'Bold — select text then click';
     boldBtn.textContent = 'B';
@@ -3279,6 +3292,7 @@ function annRender() {
     boldBtn.addEventListener('click', () => annFmtBold(bodyTA));
 
     const bulletBtn = document.createElement('button');
+    bulletBtn.type = 'button';
     bulletBtn.className = 'ann-fmt-btn';
     bulletBtn.title = 'Toggle bullet point on current line';
     bulletBtn.textContent = '•';
@@ -3301,6 +3315,11 @@ function annRender() {
       schedulePreviewUpdate();
       scheduleProjectPersist();
     });
+    // Track selection so Bold/Bullet buttons can restore it after mousedown steals focus
+    const saveAnnSel = () => { bodyTA._savedSel = { start: bodyTA.selectionStart, end: bodyTA.selectionEnd }; };
+    bodyTA.addEventListener('select', saveAnnSel);
+    bodyTA.addEventListener('mouseup', saveAnnSel);
+    bodyTA.addEventListener('keyup', saveAnnSel);
 
     // URL input for QR code (Feature 6)
     const urlRow = document.createElement('div');
@@ -3709,7 +3728,7 @@ async function saveProjectToServer(project) {
   } catch (err) {
     if (err.message && err.message.includes('409')) {
       const banner = document.getElementById('conflict-banner');
-      banner.textContent = 'This bulletin was updated by someone else. Reload to get the latest version, or continue saving to overwrite.';
+      banner.textContent = 'This bulletin was updated by someone else.';
       banner.style.display = '';
       const reloadLink = document.createElement('a');
       reloadLink.href = '#';
@@ -6526,30 +6545,49 @@ function parseClipboardSong(raw) {
   return { lyrics, copyright, ccli };
 }
 
-document.getElementById('song-db-paste-btn').addEventListener('click', async () => {
-  let text = '';
-  try {
-    text = await navigator.clipboard.readText();
-  } catch (e) {
-    alert('Could not read clipboard. Make sure you\'ve copied some text first.');
-    return;
-  }
+function _applyClipboardText(text) {
   if (!text.trim()) { alert('Clipboard is empty.'); return; }
-
   const parsed = parseClipboardSong(text);
-
   closeSdbForm();
   document.getElementById('sdb-form-heading').textContent = 'Add Song (from clipboard)';
   document.getElementById('sdb-title').value     = '';
   document.getElementById('sdb-author').value    = '';
   document.getElementById('sdb-lyrics').value    = parsed.lyrics;
-  // Merge CCLI number into copyright string if not already present
   let cr = parsed.copyright;
   if (parsed.ccli && !cr.includes(parsed.ccli)) {
     cr = (cr ? cr + '  ' : '') + `CCLI #${parsed.ccli}`;
   }
   document.getElementById('sdb-copyright').value = cr;
+}
 
+// Paste dialog fallback
+document.getElementById('sdb-paste-dialog-cancel').addEventListener('click', () => {
+  document.getElementById('sdb-paste-dialog').close();
+});
+document.getElementById('sdb-paste-dialog-ok').addEventListener('click', () => {
+  const text = document.getElementById('sdb-paste-fallback-ta').value;
+  document.getElementById('sdb-paste-dialog').close();
+  _applyClipboardText(text);
+  document.getElementById('sdb-title').scrollIntoView({ behavior: 'smooth', block: 'start' });
+  document.getElementById('sdb-title').focus();
+});
+
+document.getElementById('song-db-paste-btn').addEventListener('click', async () => {
+  let text = '';
+  try {
+    if (!navigator.clipboard || !navigator.clipboard.readText) throw new Error('unavailable');
+    text = await navigator.clipboard.readText();
+  } catch (e) {
+    // Clipboard API unavailable or permission denied — show manual paste dialog
+    const dialog = document.getElementById('sdb-paste-dialog');
+    document.getElementById('sdb-paste-fallback-ta').value = '';
+    dialog.showModal();
+    setTimeout(() => document.getElementById('sdb-paste-fallback-ta').focus(), 50);
+    return;
+  }
+  if (!text.trim()) { alert('Clipboard is empty.'); return; }
+
+  _applyClipboardText(text);
   document.getElementById('sdb-title').scrollIntoView({ behavior: 'smooth', block: 'start' });
   document.getElementById('sdb-title').focus();
 });
@@ -6781,9 +6819,16 @@ async function parsePropresenterFile(file) {
   const text = new TextDecoder('utf-8', { fatal: false }).decode(buf);
   const trimmed = text.trimStart();
 
-  // XML format (ProPresenter 5/6: .pro5, .pro6, or XML-based .pro)
-  if (trimmed.startsWith('<?xml') || trimmed.startsWith('<RV')) {
-    return _parsePropresenterXml(file.name, text);
+  // XML format — try any file that looks like XML (starts with < or <?xml)
+  // Covers ProPresenter 5/6 .pro5/.pro6 and XML-based .pro files with various root elements
+  if (trimmed.startsWith('<')) {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(text, 'text/xml');
+    const root = doc.documentElement;
+    if (root.nodeName !== 'parseerror' && root.tagName !== 'html') {
+      return _parsePropresenterXml(file.name, text);
+    }
+    // Fell through — XML parse failed, try proto7 before giving up
   }
 
   // ProPresenter 7 protobuf format
@@ -7026,10 +7071,10 @@ function buildPrintDocHtml(pagesHtml, title) {
 <meta charset="UTF-8">
 <title>${safeTitle}</title>
 <style>
+${css}
+/* Headless PDF overrides — placed after embedded CSS so page-size variables win */
 :root { --doc-page-w: ${w}in; --doc-page-h: ${h}in; }
 @page { size: ${w}in ${h}in; margin: 0; }
-${css}
-/* Headless PDF overrides */
 body { margin: 0; padding: 0; background: white !important; display: block !important; }
 header, aside, .tab-bar, .pg-break-ctrl,
 .preview-page-num, .item-insert-zone { display: none !important; }


### PR DESCRIPTION
## Summary
- **#22 (security)** — Block `/data/*` HTTP access with explicit 403; previously relied on fall-through 404
- **#26 (bug)** — Add `type="button"` to announcement Bold/Bullet toolbar buttons to prevent accidental form submission
- **#27 (bug)** — Add `_savedSel` selection tracking to announcement textarea so Bold button correctly restores cursor
- **#29 (bug)** — Remove misleading "overwrite" text from conflict banner — no such button exists
- **#39 (bug)** — Add manual paste fallback `<dialog>` when `navigator.clipboard` is unavailable or permission denied
- **#13 (bug)** — Broaden `.pro` XML detection to try any file starting with `<` as XML before falling back to proto7 parser
- **#41 (bug)** — Fix PDF export rendering content as 5.5×8.5 regardless of selected page size — CSS variable overrides were being overwritten by hardcoded `:root` values in embedded stylesheet; moved overrides after the embedded CSS so custom size wins

Closes #22
Closes #26
Closes #27
Closes #29
Closes #39
Closes #13
Closes #41

## Test plan
- [x] **#26/#27** — In announcements, place cursor in a body field and click Bold. Confirm `**text**` wraps selected text. Confirm clicking Bold with no selection inserts `**bold**` placeholder at cursor position
- [x] **#29** — Open two browser tabs with the same project. Edit and save in tab 1, then save in tab 2. Confirm conflict banner says "This bulletin was updated by someone else." with a Reload link — no mention of "overwrite"
- [ ] **#22** — Navigate directly to `https://your-server/data/settings.json`. Confirm 403 response
- [x] **#39** — Click "Paste from Clipboard" in Song Database. If clipboard API is blocked, confirm a paste dialog appears. Paste text in, click Import, confirm song form is populated
- [ ] **#13** — Import a `.pro` file that was previously rejected as "not valid XML". Confirm it now imports correctly
- [ ] **#41** — Set page size to 8.5×11 (or any non-default). Export PDF. Confirm content fills the full page correctly instead of clustering in a 5.5×8.5 corner