### PR TITLE
Fix desktop app relaunch hang

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -19,48 +19,102 @@ import webbrowser
 DESKTOP_PORT = 8765
 
 
-def _kill_stale_server(port):
-    """Kill any leftover process holding our port from a previous run."""
-    # First check if anything is listening
-    try:
-        with socket.create_connection(('127.0.0.1', port), timeout=1):
-            pass  # Something is listening — need to kill it
-    except OSError:
-        return  # Port is free, nothing to do
+def _get_pid_file():
+    """Return path to the PID file in the data directory."""
+    home = os.path.expanduser('~')
+    data_dir = os.path.join(home, 'Documents', 'bulletin-generator-data')
+    os.makedirs(data_dir, exist_ok=True)
+    return os.path.join(data_dir, 'server.pid')
 
-    # Find and kill the process using lsof (use full path for .app bundles)
-    import subprocess
+
+def _port_in_use(port):
+    """Check if something is listening on the port."""
+    try:
+        with socket.create_connection(('127.0.0.1', port), timeout=0.5):
+            return True
+    except OSError:
+        return False
+
+
+def _kill_stale_server(port):
+    """Kill any leftover process holding our port from a previous run.
+    Returns only after the port is confirmed free or all attempts exhausted."""
+    if not _port_in_use(port):
+        return True  # Port is free
+
     my_pid = os.getpid()
+    targets = set()
+
+    # Strategy 1: PID file from previous run
+    pid_file = _get_pid_file()
+    try:
+        with open(pid_file, 'r') as f:
+            old_pid = int(f.read().strip())
+        if old_pid != my_pid:
+            targets.add(old_pid)
+    except (FileNotFoundError, ValueError, OSError):
+        pass
+
+    # Strategy 2: lsof fallback
+    import subprocess
     for lsof_path in ['/usr/sbin/lsof', '/usr/bin/lsof', 'lsof']:
         try:
             result = subprocess.run(
                 [lsof_path, '-ti', f':{port}'],
                 capture_output=True, text=True, timeout=5
             )
-            if result.returncode != 0:
-                continue
-            for pid_str in result.stdout.strip().split('\n'):
-                if not pid_str:
-                    continue
-                pid = int(pid_str)
-                if pid != my_pid:
-                    os.kill(pid, signal.SIGTERM)
-            # Wait for port to free up
-            for _ in range(20):
-                time.sleep(0.2)
-                try:
-                    with socket.create_connection(('127.0.0.1', port), timeout=0.3):
-                        continue  # Still listening
-                except OSError:
-                    return  # Port freed
-            # Force kill if SIGTERM didn't work
-            for pid_str in result.stdout.strip().split('\n'):
-                if pid_str and int(pid_str) != my_pid:
-                    os.kill(int(pid_str), signal.SIGKILL)
-            time.sleep(0.5)
-            return
+            if result.returncode == 0:
+                for pid_str in result.stdout.strip().split('\n'):
+                    if pid_str:
+                        pid = int(pid_str)
+                        if pid != my_pid:
+                            targets.add(pid)
+                break
         except Exception:
             continue
+
+    if not targets:
+        # Can't identify the process — wait briefly and hope it dies
+        time.sleep(2)
+        return not _port_in_use(port)
+
+    # SIGTERM all targets
+    for pid in targets:
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except (ProcessLookupError, PermissionError):
+            pass
+
+    # Wait for port to free (up to 8 seconds)
+    for _ in range(40):
+        time.sleep(0.2)
+        if not _port_in_use(port):
+            return True
+
+    # Escalate to SIGKILL
+    for pid in targets:
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            pass
+
+    # Final wait after SIGKILL (up to 2 seconds)
+    for _ in range(10):
+        time.sleep(0.2)
+        if not _port_in_use(port):
+            return True
+
+    return False  # Couldn't free the port
+
+
+def _write_pid_file():
+    """Write current PID so future launches can kill us."""
+    try:
+        pid_file = _get_pid_file()
+        with open(pid_file, 'w') as f:
+            f.write(str(os.getpid()))
+    except OSError:
+        pass
 
 # Set desktop mode before importing server
 os.environ.setdefault('APP_MODE', 'desktop')
@@ -82,6 +136,7 @@ _load_desktop_config()
 
 
 def _wait_for_server(port, timeout=15):
+    """Wait for OUR new server to start listening."""
     deadline = time.time() + timeout
     while time.time() < deadline:
         try:
@@ -92,15 +147,71 @@ def _wait_for_server(port, timeout=15):
     return False
 
 
+def _is_our_server(port):
+    """Check if our Bulletin Generator server is already running on the port."""
+    try:
+        import http.client
+        conn = http.client.HTTPConnection('127.0.0.1', port, timeout=2)
+        conn.request('GET', '/api/bootstrap')
+        resp = conn.getresponse()
+        body = resp.read().decode('utf-8', errors='replace')
+        conn.close()
+        return 'appMode' in body
+    except Exception:
+        return False
+
+
+def _start_server_detached():
+    """Start the server as a detached background process that survives app exit."""
+    import subprocess
+
+    # Find the real Python/executable path
+    exe = sys.executable
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    server_script = os.path.join(script_dir, 'server.py')
+
+    # For PyInstaller bundled app, run server in-process but forked
+    pid = os.fork()
+    if pid == 0:
+        # Child process — become the background server
+        os.setsid()  # Detach from parent session
+        # Close inherited file descriptors
+        try:
+            devnull = os.open(os.devnull, os.O_RDWR)
+            os.dup2(devnull, 0)
+            os.dup2(devnull, 1)
+            os.dup2(devnull, 2)
+            os.close(devnull)
+        except OSError:
+            pass
+
+        # Write PID file for the server process
+        _write_pid_file()
+
+        import server
+        server.run_server(DESKTOP_PORT)
+        sys.exit(0)
+    else:
+        # Parent process — return immediately so the .app exits
+        return pid
+
+
 def main():
-    # Kill any leftover server from a previous run
-    _kill_stale_server(DESKTOP_PORT)
+    # If our server is already running, just open the browser and exit
+    if _port_in_use(DESKTOP_PORT) and _is_our_server(DESKTOP_PORT):
+        webbrowser.open(f'http://localhost:{DESKTOP_PORT}/')
+        return
 
-    import server
+    # Something else is on our port — kill it
+    if _port_in_use(DESKTOP_PORT):
+        port_free = _kill_stale_server(DESKTOP_PORT)
+        if not port_free:
+            pass  # Try anyway — SO_REUSEADDR might save us
 
-    t = threading.Thread(target=server.run_server, args=(DESKTOP_PORT,), daemon=True)
-    t.start()
+    # Start server as a detached background process
+    _start_server_detached()
 
+    # Wait for server to come up, then open browser
     if _wait_for_server(DESKTOP_PORT):
         webbrowser.open(f'http://localhost:{DESKTOP_PORT}/')
     else:
@@ -108,8 +219,7 @@ def main():
         print('Make sure no other app is using that port and try again.')
         sys.exit(1)
 
-    # Keep the process alive until the server thread ends
-    t.join()
+    # Parent exits — the .app closes, but the server keeps running in background
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- Fork the HTTP server as a detached background process so the `.app` exits quickly after launching
- Fixes macOS single-instance behavior where re-opening the app caused it to bounce and hang indefinitely
- Subsequent launches detect the running server and just open a new browser tab
- Added PID file (`~/Documents/bulletin-generator-data/server.pid`) for reliable stale-server cleanup

## Test plan
- [ ] First launch starts server and opens browser
- [ ] Second launch (while server running) opens new browser tab instantly
- [ ] After force-killing the server process, next launch starts a fresh server
- [ ] No dock icon lingers after browser opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)