### PR TITLE
fix: tier 2 issues — normalizePlanNotes, ann scroll, church name, desktop mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,10 +114,6 @@
         <label for="svc-date">Date</label>
         <input type="text" id="svc-date" placeholder="e.g. January 5, 2025" />
       </div>
-      <div class="field-row">
-        <label for="svc-church">Church Name</label>
-        <input type="text" id="svc-church" placeholder="e.g. Visalia Christian Reformed Church" />
-      </div>
     </div>
 
     <!-- Cover Image -->
@@ -365,6 +361,13 @@
     <!-- ── Church Branding ──────────────────────────────────────────────── -->
     <div class="stg-group">
       <div class="stg-group-heading" id="stg-branding">Church Branding</div>
+
+      <div class="stg-card">
+        <div class="stg-card-label">Church Name</div>
+        <p class="section-hint">Appears on the bulletin cover. Set once here and it carries across all bulletins automatically.</p>
+        <input type="text" id="svc-church" placeholder="e.g. Visalia Christian Reformed Church"
+               style="width:100%; box-sizing:border-box; padding:0.25rem 0.4rem; font-size:0.78rem; border:1px solid var(--border); border-radius:var(--radius); margin-top:0.15rem;" />
+      </div>
 
       <div class="stg-card">
         <div class="stg-card-label">Give Online URL</div>

--- a/src/js/announcements.js
+++ b/src/js/announcements.js
@@ -4,6 +4,7 @@ function annRender() {
   annData.forEach((ann, idx) => {
     const card = document.createElement('div');
     card.className = 'ann-card';
+    card.dataset.annIdx = idx;
 
     // Row 1: title input + move + delete
     const row1 = document.createElement('div');
@@ -211,5 +212,16 @@ function fmtItalic(ta) {
   ta.focus();
   ta.dispatchEvent(new Event('input', { bubbles: true }));
 }
+
+// ─── Linked preview scroll ────────────────────────────────────────────────────
+// Clicking an announcement card scrolls the preview to that announcement,
+// mirroring the linked-preview behaviour of the Order of Worship editor.
+annList.addEventListener('click', e => {
+  const card = e.target.closest('.ann-card');
+  if (!card) return;
+  const idx = parseInt(card.dataset.annIdx, 10);
+  if (!Number.isInteger(idx)) return;
+  if (typeof scrollPreviewToAnn === 'function') scrollPreviewToAnn(idx);
+});
 
 // ─── Per-item formatting toolbar ──────────────────────────────────────────────

--- a/src/js/editor.js
+++ b/src/js/editor.js
@@ -81,6 +81,16 @@ logoImgInput.addEventListener('change', () => {
 });
 logoImgClear.addEventListener('click', () => applyStaffLogo(null, ''));
 
+// ─── Church Name (Settings → Church Branding) ─────────────────────────────────
+function restoreChurchName() {
+  const saved = _serverSettings.churchName || '';
+  if (saved) svcChurch.value = saved;
+}
+svcChurch.addEventListener('input', () => {
+  apiFetch('/api/settings', 'POST', { churchName: svcChurch.value }).catch(() => {});
+  schedulePreviewUpdate();
+});
+
 // ─── Give Online URL (Feature 7) ──────────────────────────────────────────────
 giveOnlineUrlInput.addEventListener('input', () => {
   giveOnlineUrl = giveOnlineUrlInput.value;
@@ -365,6 +375,32 @@ function scrollPreviewToItem(idx, behavior = 'smooth') {
   scrollElementIntoContainer(previewPane, linked, behavior);
   linkedPreviewTimer = setTimeout(() => {
     clearLinkedPreviewHighlight();
+  }, 1600);
+}
+
+// Scroll the preview pane to a specific announcement and briefly highlight it.
+// Mirrors scrollPreviewToItem but uses data-preview-ann-idx instead of data-preview-idx.
+function scrollPreviewToAnn(idx) {
+  const linked = previewPane.querySelector(`[data-preview-ann-idx="${idx}"]`);
+  if (!linked) {
+    // Announcement page may not be visible yet — scroll to the section heading instead
+    const heading = previewPane.querySelector('[data-preview-section="announcements"]');
+    if (heading) scrollElementIntoContainer(previewPane, heading, 'smooth');
+    return;
+  }
+  clearTimeout(linkedPreviewTimer);
+  // Highlight both the preview element and the editor card
+  previewPane.querySelectorAll('[data-preview-ann-idx].is-linked')
+    .forEach(el => el.classList.remove('is-linked'));
+  annList.querySelectorAll('.ann-card.is-linked')
+    .forEach(el => el.classList.remove('is-linked'));
+  linked.classList.add('is-linked');
+  const card = annList.querySelector(`.ann-card[data-ann-idx="${idx}"]`);
+  if (card) card.classList.add('is-linked');
+  scrollElementIntoContainer(previewPane, linked, 'smooth');
+  linkedPreviewTimer = setTimeout(() => {
+    linked.classList.remove('is-linked');
+    if (card) card.classList.remove('is-linked');
   }, 1600);
 }
 

--- a/src/js/pco.js
+++ b/src/js/pco.js
@@ -273,6 +273,12 @@ function applyPcoData(planResp, itemsResp, notesResp) {
 
 // Convert raw PCO notes response into a flat normalized array.
 function normalizePlanNotes(notesResp) {
+  // Guard against null/undefined, non-objects, or a raw array being passed
+  // instead of the expected { data: [...] } JSON:API envelope.
+  if (!notesResp || typeof notesResp !== 'object' || Array.isArray(notesResp)) {
+    console.warn('normalizePlanNotes: unexpected input shape', notesResp);
+    return [];
+  }
   return (notesResp.data || []).map(note => {
     const a = note.attributes || {};
     const title = (a.category_name || '').trim();

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -113,7 +113,7 @@ async function saveProjectToServer(project) {
       reloadLink.addEventListener('click', e => { e.preventDefault(); loadProjectById(project.id); });
       banner.appendChild(reloadLink);
     } else {
-      setStatus('Could not save project to server.', 'error');
+      setStatus(isDesktopMode() ? 'Could not save project.' : 'Could not save project to server.', 'error');
     }
   }
 }
@@ -388,7 +388,7 @@ function clearEditorForNewProject() {
   activeProjectId = '';
   svcTitle.value = '';
   svcDate.value = '';
-  svcChurch.value = '';
+  svcChurch.value = _serverSettings.churchName || ''; // inherit org-level default
   servingSchedule = null;
   volRender();
   optCover.checked = true;
@@ -445,6 +445,7 @@ async function restoreOnStartup() {
 
   // Always restore global logo from server settings first
   restoreDefaultStaffLogo();
+  restoreChurchName();
   restoreGiveOnlineUrl();
   restoreEditorIdentity();
 

--- a/src/js/state.js
+++ b/src/js/state.js
@@ -23,7 +23,10 @@ let _loadedRevision = null;   // revision of the project as loaded from server
 let _editorDisplayName = '';  // local editor identity
 let _staleCheckTimer = null;
 
-const PROJECTS_STORAGE_KEY = 'worshipProjectsV1';
+// Note: both server mode and desktop mode persist projects through the local
+// Python server API (data/projects.json). localStorage is only used to track
+// the active project ID across page reloads and to store the unsaved draft.
+// PROJECTS_STORAGE_KEY was an earlier localStorage-only path that is no longer used.
 const ACTIVE_PROJECT_STORAGE_KEY = 'worshipActiveProjectId';
 const DRAFT_STORAGE_KEY = 'worshipProjectDraftV1';
 const TYPE_FORMATS_KEY = 'worshipTypeFormatsV1';


### PR DESCRIPTION
## Summary

- **#30** — Hardened \`normalizePlanNotes()\` against null/non-object/raw-array input with an early return + console warning; current PCO behavior unchanged
- **#52** — Clicking an announcement card now scrolls the preview to that announcement with a brief highlight, matching the OOW linked-preview UX
- **#51** — Church name moved from Service Details to Settings > Church Branding; saved/restored via \`/api/settings\`; new projects inherit the value from Settings automatically
- **#21** — Removed unused \`PROJECTS_STORAGE_KEY\` constant (dead code); added clarifying comment on persistence architecture; save error message is now mode-aware in desktop mode

## Test plan

- [x] #52: Click announcement card in editor → preview scrolls and highlights that announcement
- [x] #51: Set church name in Settings → persists across sessions; new project pre-fills from Settings

Closes #30, #52, #51, #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)