### PR TITLE
fix(#64): sticky song DB search/sort controls, list-only scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -276,8 +276,10 @@
           </div>
         </div>
         <div class="sdb-count" id="sdb-count"></div>
-        <div id="song-db-list"></div>
-        <div id="song-db-empty">No songs yet — add your first song above.</div>
+        <div id="song-db-scroll">
+          <div id="song-db-list"></div>
+          <div id="song-db-empty">No songs yet — add your first song above.</div>
+        </div>
       </div>
 
       <!-- Right: add/edit form -->

--- a/src/css/pages.css
+++ b/src/css/pages.css
@@ -1,7 +1,7 @@
     /* ─── Song Database Page ─────────────────────────────────────────────────── */
     #page-songdb {
       flex-direction: column;
-      overflow-y: scroll;
+      overflow: hidden;
       background: var(--bg);
       padding: 1.75rem 2rem;
     }
@@ -86,6 +86,11 @@
       max-width: 1100px;
       margin: 0 auto;
       width: 100%;
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
+      overflow: hidden;
     }
     .sdb-page-header {
       display: flex;
@@ -106,15 +111,20 @@
       display: grid;
       grid-template-columns: 1fr 400px;
       gap: 1.5rem;
-      align-items: start;
+      flex: 1;
+      min-height: 0;
+      overflow: hidden;
     }
-    .sdb-list-col { min-width: 0; }
+    .sdb-list-col {
+      min-width: 0;
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
+      overflow: hidden;
+    }
     .sdb-form-col {
       min-width: 0;
-      position: sticky;
-      top: 0;
-      align-self: start;
-      max-height: calc(100vh - 140px);
+      max-height: 100%;
       overflow-y: auto;
     }
     .sdb-form-sticky {
@@ -140,7 +150,13 @@
       color: var(--muted);
       margin-bottom: 0.75rem;
     }
-    #sdb-controls-page { margin-bottom: 0.75rem; }
+    #sdb-controls-page { margin-bottom: 0.75rem; flex-shrink: 0; }
+    .sdb-count { flex-shrink: 0; }
+    #song-db-scroll {
+      flex: 1;
+      overflow-y: auto;
+      min-height: 0;
+    }
     #song-db-search { width: 100%; margin-bottom: 0.4rem; }
     .sdb-sort-row {
       display: flex;


### PR DESCRIPTION
Pure CSS layout change. Search input, sort dropdowns, and count are pinned at the top; only the song list scrolls. Mirrors the existing Add New Song form column UX. Closes #64.