### PR TITLE
fix(#69): extend calendar window to 8 days

### DIFF
--- a/server.py
+++ b/server.py
@@ -369,7 +369,7 @@ def get_week_window():
     dow = today.weekday()  # Monday=0, Sunday=6
     days_until_sunday = (6 - dow) % 7  # 0 if today is Sunday
     start = today + timedelta(days=days_until_sunday)
-    end   = start + timedelta(days=6)
+    end   = start + timedelta(days=7)
     return start, end
 
 


### PR DESCRIPTION
## Summary
- Changes `get_week_window()` from `timedelta(days=6)` to `timedelta(days=7)` so the calendar page shows all events in the next 8 days instead of 7

## Test plan
- [ ] Verify calendar page shows events through the 8th day
- [ ] Confirm live preview and PDF output match the expanded window

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)