### PR TITLE
Fix: PCO connect button uses OAuth in all modes

### DIFF
--- a/src/js/pco.js
+++ b/src/js/pco.js
@@ -944,29 +944,9 @@ async function googleLoadCalendarList() {
   }
 }
 
-// Desktop: clicking Connect Planning Center navigates to OAuth start
-// Server: clicking Retry Connection checks if credentials are now working
-document.getElementById('pco-connect-btn').addEventListener('click', async () => {
-  if (isDesktopMode()) {
-    window.location.href = '/oauth/pco/start';
-    return;
-  }
-  // Server mode — retry Basic auth check
-  const btn = document.getElementById('pco-connect-btn');
-  btn.disabled = true;
-  btn.textContent = 'Checking…';
-  pcoSetMsg('pco-creds-msg', '');
-  try {
-    await pcoGet('/service_types?per_page=1');
-    _publicConfig.pcoConfigured = true;
-    pcoShowImportView();
-    pcoLoadServiceTypes();
-  } catch (err) {
-    pcoSetMsg('pco-creds-msg', err.message, 'error');
-  } finally {
-    btn.disabled = false;
-    btn.textContent = 'Retry Connection';
-  }
+// Clicking Connect Planning Center navigates to OAuth start
+document.getElementById('pco-connect-btn').addEventListener('click', () => {
+  window.location.href = '/oauth/pco/start';
 });
 
 document.getElementById('pco-disconnect-btn').addEventListener('click', async () => {

--- a/worship-booklet.html
+++ b/worship-booklet.html
@@ -8854,29 +8854,9 @@ async function googleLoadCalendarList() {
   }
 }
 
-// Desktop: clicking Connect Planning Center navigates to OAuth start
-// Server: clicking Retry Connection checks if credentials are now working
-document.getElementById('pco-connect-btn').addEventListener('click', async () => {
-  if (isDesktopMode()) {
-    window.location.href = '/oauth/pco/start';
-    return;
-  }
-  // Server mode — retry Basic auth check
-  const btn = document.getElementById('pco-connect-btn');
-  btn.disabled = true;
-  btn.textContent = 'Checking…';
-  pcoSetMsg('pco-creds-msg', '');
-  try {
-    await pcoGet('/service_types?per_page=1');
-    _publicConfig.pcoConfigured = true;
-    pcoShowImportView();
-    pcoLoadServiceTypes();
-  } catch (err) {
-    pcoSetMsg('pco-creds-msg', err.message, 'error');
-  } finally {
-    btn.disabled = false;
-    btn.textContent = 'Retry Connection';
-  }
+// Clicking Connect Planning Center navigates to OAuth start
+document.getElementById('pco-connect-btn').addEventListener('click', () => {
+  window.location.href = '/oauth/pco/start';
 });
 
 document.getElementById('pco-disconnect-btn').addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- Remove old server-mode Basic auth retry logic from PCO connect button
- Button now always redirects to `/oauth/pco/start` for OAuth flow in both desktop and server modes

## Test plan
- [ ] Deploy to Synology, click "Connect Planning Center", verify OAuth redirect works
- [ ] Verify desktop app OAuth flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)