### PR TITLE
Fix #50: Store editor identity per-client in server mode

### DIFF
--- a/src/js/api.js
+++ b/src/js/api.js
@@ -67,7 +67,7 @@ async function loadAllFromServer() {
       activeDocTemplate = Object.assign({ pageSize: '5.5x8.5' }, _serverSettings.docTemplate);
     }
     applyDocTemplate();
-    if (typeof _serverSettings.editorDisplayName === 'string') {
+    if (!isServerMode() && typeof _serverSettings.editorDisplayName === 'string') {
       _editorDisplayName = _serverSettings.editorDisplayName;
     }
   } catch (e) {

--- a/src/js/editor.js
+++ b/src/js/editor.js
@@ -53,6 +53,12 @@ function restoreGiveOnlineUrl() {
 }
 
 function restoreEditorIdentity() {
+  if (isServerMode()) {
+    try {
+      const local = localStorage.getItem('editorDisplayName');
+      if (local) _editorDisplayName = local;
+    } catch (_) {}
+  }
   if (_editorDisplayName) editorDisplayNameInput.value = _editorDisplayName;
   applyIdentitySectionVisibility();
 }
@@ -106,7 +112,11 @@ function applyIdentitySectionVisibility() {
 }
 editorDisplayNameInput.addEventListener('input', () => {
   _editorDisplayName = editorDisplayNameInput.value.trim();
-  apiFetch('/api/settings', 'POST', { editorDisplayName: _editorDisplayName }).catch(() => {});
+  if (isServerMode()) {
+    try { localStorage.setItem('editorDisplayName', _editorDisplayName); } catch (_) {}
+  } else {
+    apiFetch('/api/settings', 'POST', { editorDisplayName: _editorDisplayName }).catch(() => {});
+  }
 });
 
 // ─── PDF text extraction ──────────────────────────────────────────────────────

--- a/worship-booklet.html
+++ b/worship-booklet.html
@@ -2528,7 +2528,7 @@ async function loadAllFromServer() {
       activeDocTemplate = Object.assign({ pageSize: '5.5x8.5' }, _serverSettings.docTemplate);
     }
     applyDocTemplate();
-    if (typeof _serverSettings.editorDisplayName === 'string') {
+    if (!isServerMode() && typeof _serverSettings.editorDisplayName === 'string') {
       _editorDisplayName = _serverSettings.editorDisplayName;
     }
   } catch (e) {
@@ -2792,6 +2792,12 @@ function restoreGiveOnlineUrl() {
 }
 
 function restoreEditorIdentity() {
+  if (isServerMode()) {
+    try {
+      const local = localStorage.getItem('editorDisplayName');
+      if (local) _editorDisplayName = local;
+    } catch (_) {}
+  }
   if (_editorDisplayName) editorDisplayNameInput.value = _editorDisplayName;
   applyIdentitySectionVisibility();
 }
@@ -2835,7 +2841,11 @@ function applyIdentitySectionVisibility() {
 }
 editorDisplayNameInput.addEventListener('input', () => {
   _editorDisplayName = editorDisplayNameInput.value.trim();
-  apiFetch('/api/settings', 'POST', { editorDisplayName: _editorDisplayName }).catch(() => {});
+  if (isServerMode()) {
+    try { localStorage.setItem('editorDisplayName', _editorDisplayName); } catch (_) {}
+  } else {
+    apiFetch('/api/settings', 'POST', { editorDisplayName: _editorDisplayName }).catch(() => {});
+  }
 });
 
 // ─── PDF text extraction ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- In server mode, editor display name now stored in browser `localStorage` instead of shared `settings.json`
- Each user's name persists in their own browser without overwriting others
- Desktop mode continues using server-side storage (single user, no conflict)
- Project `createdBy`/`updatedBy` attribution still works — reads from the client-local name

Fixes #50

## Test plan
- [ ] Open app in two different browsers, set different editor names
- [ ] Verify names don't overwrite each other
- [ ] Save a project from each browser, verify `updatedBy` shows the correct name
- [ ] Verify desktop mode still saves editor name to settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)