### PR TITLE
Phase 1: Staff page fixes, conflict banner, calendar token refresh (#78 #80 #82)

### DIFF
--- a/server.py
+++ b/server.py
@@ -459,7 +459,11 @@ def fetch_and_parse_calendars(urls, exclude_titles):
 
 
 def fetch_google_cal_events(auth_header, calendar_ids, exclude_titles):
-    """Fetch this week's events from Google Calendar API for given calendar IDs."""
+    """Fetch this week's events from Google Calendar API for given calendar IDs.
+    Returns None if any calendar returns 401/403 (signals auth failure to caller).
+    Returns [] if auth succeeds but there are no events in the window.
+    Returns a list of events otherwise.
+    """
     start_date, end_date = get_week_window()
     time_min = datetime.combine(start_date, datetime.min.time()).replace(tzinfo=timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
     time_max = datetime.combine(end_date,   datetime.max.time().replace(microsecond=0)).replace(tzinfo=timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
@@ -483,6 +487,13 @@ def fetch_google_cal_events(auth_header, calendar_ids, exclude_titles):
         try:
             with urllib.request.urlopen(req, timeout=10) as resp:
                 data = json.loads(resp.read())
+        except urllib.error.HTTPError as e:
+            if e.code in (401, 403):
+                # Auth failure — signal caller to refresh token, not just an empty calendar
+                print(f'  [google-cal] Auth error ({e.code}) for calendar {cal_id} — token may be expired')
+                return None
+            print(f'  [google-cal] HTTP {e.code} fetching calendar {cal_id}: {e}')
+            continue
         except Exception as e:
             print(f'  [google-cal] Failed to fetch calendar {cal_id}: {e}')
             continue
@@ -1403,11 +1414,13 @@ class Handler(http.server.SimpleHTTPRequestHandler):
             google_auth = _google_auth_header()
             if google_auth and google_cal_ids:
                 result = fetch_google_cal_events(google_auth, google_cal_ids, exclude)
-                if result is None or (isinstance(result, list) and len(result) == 0 and google_cal_ids):
-                    # On 401 try refreshing once
+                if result is None:
+                    # None means auth failure (401/403) — refresh token and retry once
                     new_auth = _refresh_google_token()
                     if new_auth:
                         result = fetch_google_cal_events(new_auth, google_cal_ids, exclude)
+                    else:
+                        result = []
             else:
                 result = fetch_and_parse_calendars(urls, exclude)
 

--- a/src/css/pages.css
+++ b/src/css/pages.css
@@ -466,7 +466,7 @@
     .staff-table {
       width: 100%;
       border-collapse: collapse;
-      font-size: 0.70rem;
+      font-size: 0.58rem;
       font-family: var(--font-sans);
     }
     .staff-table tr {
@@ -490,7 +490,7 @@
     }
     .staff-table .semail {
       color: #888;
-      font-size: 0.62rem;
+      font-size: 0.52rem;
       font-style: italic;
       text-align: right;
       white-space: nowrap;
@@ -504,7 +504,7 @@
     .staff-flex-wrap {
       display: flex;
       flex-direction: column;
-      overflow: hidden;
+      overflow: visible;
     }
     /* Stretchy gap between staff table and logo — QR centers itself here */
     .staff-give-flex {
@@ -525,7 +525,7 @@
     }
     .staff-logo-wrap img {
       max-width: 2.3in;
-      max-height: 0.9in;
+      max-height: 1.2in;
       object-fit: contain;
     }
 

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -110,16 +110,16 @@ async function saveProjectToServer(project) {
   } catch (err) {
     if (err.status === 409) {
       const banner = document.getElementById('conflict-banner');
-      banner.textContent = 'This bulletin was updated by someone else.';
+      banner.innerHTML = '';
+      const bannerText = document.createTextNode('This bulletin was updated by someone else.');
+      banner.appendChild(bannerText);
       banner.style.display = '';
-      if (!banner.querySelector('a')) {
-        const reloadLink = document.createElement('a');
-        reloadLink.href = '#';
-        reloadLink.textContent = ' Reload latest';
-        reloadLink.style.marginLeft = '0.4rem';
-        reloadLink.addEventListener('click', e => { e.preventDefault(); loadProjectById(project.id); });
-        banner.appendChild(reloadLink);
-      }
+      const reloadLink = document.createElement('a');
+      reloadLink.href = '#';
+      reloadLink.textContent = ' Reload latest';
+      reloadLink.style.marginLeft = '0.4rem';
+      reloadLink.addEventListener('click', e => { e.preventDefault(); loadProjectById(project.id); });
+      banner.appendChild(reloadLink);
     } else {
       setStatus(isDesktopMode() ? 'Could not save project.' : 'Could not save project to server.', 'error');
     }
@@ -457,6 +457,7 @@ function deleteActiveProject() {
 async function restoreOnStartup() {
   await loadAllFromServer();
   renderSongDb();
+  renderStaffEditor(); // re-render now that staffData is loaded from server
 
   // Always restore global logo from server settings first
   restoreDefaultStaffLogo();


### PR DESCRIPTION
## Summary
- **#82** Staff editor showed placeholder data on load; font too large on booklet page; logo was clipped at bottom
- **#80** Google Calendar token refresh was firing on legitimately empty event lists, not just actual 401s
- **#78** Conflict banner could accumulate duplicate "Reload latest" links across repeated 409s

## Changes

### Staff page (#82)
- `renderStaffEditor()` now called after `loadAllFromServer()` resolves so editor always shows real server data instead of placeholder defaults
- Staff table font reduced from `0.70rem` → `0.58rem`, email column `0.62rem` → `0.52rem` (compensates for the recent base font-size increase)
- Logo `max-height` increased `0.9in` → `1.2in`; `staff-flex-wrap` overflow changed `hidden` → `visible` to prevent logo clipping

### Calendar token refresh (#80)
- `fetch_google_cal_events()` now returns `None` specifically on 401/403 (auth failure) vs `[]` (no events)
- `_handle_cal()` only retries with a refreshed token when result is `None` — not on an empty event list

### Conflict banner (#78)
- Banner content is now fully cleared via `innerHTML = ''` before each 409 rebuild, making duplicate link accumulation impossible

## Test plan
- [ ] Open app — staff editor should show real saved names, not "Jane Example"
- [ ] Connect a Google Calendar with no events this week — confirm no unnecessary token refresh in server logs
- [ ] Simulate expired Google token — confirm token refresh still triggers and calendar reloads
- [ ] Trigger two 409 conflicts in a row — confirm "Reload latest" link appears only once

🤖 Generated with [Claude Code](https://claude.com/claude-code)