### PR TITLE
fix: surface actionable Drive API errors instead of generic 502

### DIFF
--- a/server.py
+++ b/server.py
@@ -1474,7 +1474,26 @@ class Handler(http.server.SimpleHTTPRequestHandler):
                     err_body = e.read().decode('utf-8', errors='replace')[:300]
                 except Exception:
                     pass
-                self._send_json({"error": f"Drive API returned HTTP {e.code}: {err_body}"}, 502)
+                if e.code == 403:
+                    self._send_json({
+                        "error": "Google Drive permission denied. Check that the folder ID is correct and the account has write access.",
+                        "code": "drive_permission_denied",
+                        "detail": err_body,
+                    }, 403)
+                elif e.code == 404:
+                    self._send_json({
+                        "error": "Google Drive folder not found. Check the folder ID in Settings.",
+                        "code": "drive_folder_not_found",
+                        "detail": err_body,
+                    }, 404)
+                elif e.code == 400:
+                    self._send_json({
+                        "error": f"Google Drive rejected the upload request: {err_body}",
+                        "code": "drive_bad_request",
+                        "detail": err_body,
+                    }, 400)
+                else:
+                    self._send_json({"error": f"Drive API returned HTTP {e.code}: {err_body}"}, 502)
                 return
         except Exception as e:
             self._send_json({"error": f"Drive upload failed: {e}"}, 500)

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -7,7 +7,16 @@ async function apiFetch(path, method = 'GET', body = null) {
     opts.body = JSON.stringify(body);
   }
   const res = await fetch(path, opts);
-  if (!res.ok) { const e = new Error(`API ${method} ${path} → ${res.status}`); e.status = res.status; throw e; }
+  if (!res.ok) {
+    let errData = null;
+    try { errData = await res.json(); } catch (_) {}
+    const msg = errData?.error || `API ${method} ${path} → ${res.status}`;
+    const e = new Error(msg);
+    e.status = res.status;
+    e.code = errData?.code || null;
+    e.detail = errData?.detail || null;
+    throw e;
+  }
   return res.json();
 }
 

--- a/tests/test_drive.py
+++ b/tests/test_drive.py
@@ -225,7 +225,7 @@ class TestDriveUpload:
 
         assert b'folder99' in captured_req['body']
 
-    def test_upload_http_error_returns_502(self, tmp_path):
+    def test_upload_drive_403_returns_403_with_message(self, tmp_path):
         settings_file = tmp_path / 'settings.json'
         server._write_json(settings_file, {
             'googleAccessToken': 'tok',
@@ -233,6 +233,39 @@ class TestDriveUpload:
         })
         h = StubDriveHandler({'filename': 'test.pdf', 'content': 'SGVsbG8=', 'mimeType': 'application/pdf'})
         err = urllib.error.HTTPError(url='', code=403, msg='Forbidden', hdrs=None, fp=BytesIO(b'forbidden'))
+        with patch('urllib.request.urlopen', side_effect=err), \
+             patch('server.SETTINGS_FILE', settings_file):
+            h._handle_drive_upload()
+        body, status = h._responses[0]
+        assert status == 403
+        assert body.get('code') == 'drive_permission_denied'
+        assert 'permission' in body.get('error', '').lower()
+
+    def test_upload_drive_404_returns_404_with_message(self, tmp_path):
+        settings_file = tmp_path / 'settings.json'
+        server._write_json(settings_file, {
+            'googleAccessToken': 'tok',
+            'googleDriveScopeGranted': True,
+            'googleDriveFolderId': 'bad-folder-id',
+        })
+        h = StubDriveHandler({'filename': 'test.pdf', 'content': 'SGVsbG8=', 'mimeType': 'application/pdf'})
+        err = urllib.error.HTTPError(url='', code=404, msg='Not Found', hdrs=None, fp=BytesIO(b'not found'))
+        with patch('urllib.request.urlopen', side_effect=err), \
+             patch('server.SETTINGS_FILE', settings_file):
+            h._handle_drive_upload()
+        body, status = h._responses[0]
+        assert status == 404
+        assert body.get('code') == 'drive_folder_not_found'
+        assert 'folder' in body.get('error', '').lower()
+
+    def test_upload_unknown_http_error_returns_502(self, tmp_path):
+        settings_file = tmp_path / 'settings.json'
+        server._write_json(settings_file, {
+            'googleAccessToken': 'tok',
+            'googleDriveScopeGranted': True,
+        })
+        h = StubDriveHandler({'filename': 'test.pdf', 'content': 'SGVsbG8=', 'mimeType': 'application/pdf'})
+        err = urllib.error.HTTPError(url='', code=500, msg='Internal Server Error', hdrs=None, fp=BytesIO(b'server error'))
         with patch('urllib.request.urlopen', side_effect=err), \
              patch('server.SETTINGS_FILE', settings_file):
             h._handle_drive_upload()


### PR DESCRIPTION
## Summary

Fixes #141 — Google Drive upload failures were showing a generic `Drive save failed: API POST /api/drive/upload → 502` toast regardless of the real cause, making it impossible for users to self-diagnose.

Three layers of error suppression are fixed:

- **`server.py`** — `_handle_drive_upload()` previously collapsed all non-401 Drive API rejections into HTTP 502. Now maps common errors to their correct codes:
  - `403` → `403` with `"Google Drive permission denied..."` + `code: drive_permission_denied`
  - `404` → `404` with `"Google Drive folder not found..."` + `code: drive_folder_not_found`
  - `400` → `400` with the Drive rejection detail + `code: drive_bad_request`
  - All other non-401 errors still return `502`

- **`src/js/api.js`** — `apiFetch()` previously threw `Error("API POST /path → 502")` without reading the response body. Now parses the JSON error payload and uses `errData.error` as the thrown message. Also exposes `e.code` and `e.detail` on the thrown error for any caller that wants structured context.

- **`tests/test_drive.py`** — The existing `test_upload_http_error_returns_502` was incorrect: it passed a `403` HTTPError but asserted `status == 502`. Replaced with three focused tests:
  - `test_upload_drive_403_returns_403_with_message` — checks status, `code`, and message text
  - `test_upload_drive_404_returns_404_with_message` — checks status, `code`, and message text
  - `test_upload_unknown_http_error_returns_502` — confirms true upstream errors still return 502

## Test plan

- [x] `pytest tests/test_drive.py` — 14/14 passed
- [ ] Manually trigger a Drive save with an invalid folder ID → should now show "Google Drive folder not found. Check the folder ID in Settings."
- [ ] Manually trigger a Drive save without write permission → should show "Google Drive permission denied..."

## Acceptance criteria from issue

- [x] Invalid/stale Google Drive folder IDs produce a specific error in the UI
- [x] Drive permission/scope failures produce a specific error in the UI
- [x] `apiFetch()` preserves structured backend error details for failed JSON responses
- [x] `/api/drive/upload` no longer reports all non-401 Drive API rejections as `502`
- [x] Tests cover Drive `403`/`404` error propagation

🤖 Generated with [Claude Code](https://claude.com/claude-code)