### PR TITLE
fix: PDF CSS vars, calendar carryover filter, serving schedule rendering, children dismissed label

### DIFF
--- a/docs/superpowers/plans/2026-04-27-collaboration-v1-postgres-google-auth.md
+++ b/docs/superpowers/plans/2026-04-27-collaboration-v1-postgres-google-auth.md
@@ -1,0 +1,245 @@
+# Collaboration V1: Postgres, Google Auth, and Workspace Sharing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move server mode from shared JSON files to authenticated, per-user project ownership with explicit workspace sharing, revision history, and a safe migration path for old data.
+
+**Architecture:** Desktop mode keeps the current local file-backed behavior. Server mode uses Postgres for structured app data, Google Workspace OAuth for identity, and transactional project saves with optimistic revision checks. Large binary/font files remain on disk for v1, with Postgres storing metadata and paths.
+
+**Tech Stack:** Python `http.server` app, vanilla JS frontend, Docker Compose, Postgres 16, psycopg 3 or equivalent Python driver, signed HTTP-only session cookies, Google OAuth 2.0 / OpenID Connect.
+
+---
+
+## Current State Summary
+
+- `server.py` reads and writes `data/projects.json`, `data/announcements.json`, `data/settings.json`, `data/song_database.json`, and `data/templates.json`.
+- Server mode already has coarse project revision conflict protection using `project.revision` and `_clientRevision`.
+- Google OAuth currently stores one shared server token in `settings.json`; it is used for Calendar and Drive, not for app login.
+- Frontend startup currently loads the remembered active project, then falls back to the newest server project, which can surprise users in a shared deployment.
+- Desktop and server mode are already separate concepts through `APP_MODE`.
+
+## Target Data Ownership
+
+### Move to Postgres in server mode
+
+- Users and sessions.
+- Projects, project ownership, visibility, current state, current revision.
+- Project revision snapshots and audit metadata.
+- Organization-level settings currently in `settings.json`.
+- Per-user settings split out of current global settings where needed.
+- Announcements.
+- Song database.
+- Templates and template metadata.
+- Font metadata.
+- Migration bookkeeping and import status.
+
+### Keep on filesystem in server mode
+
+- Uploaded font binary files under `data/fonts/user`.
+- Cached Google Font CSS and downloaded font assets under `data/fonts/cache`.
+- Optional exported PDFs/ZIPs if future work persists generated output.
+
+### Keep JSON/local files in desktop mode
+
+- Existing desktop behavior for projects, settings, announcements, songs, templates, and fonts.
+- No required Google login in desktop mode.
+
+## Proposed Postgres Tables
+
+```sql
+users (
+  id uuid primary key,
+  google_sub text unique not null,
+  email text unique not null,
+  display_name text not null,
+  avatar_url text,
+  domain text not null,
+  last_login_at timestamptz not null,
+  created_at timestamptz not null
+)
+
+sessions (
+  id uuid primary key,
+  user_id uuid not null references users(id) on delete cascade,
+  token_hash text unique not null,
+  expires_at timestamptz not null,
+  created_at timestamptz not null
+)
+
+projects (
+  id text primary key,
+  name text not null,
+  owner_user_id uuid references users(id),
+  owner_email text,
+  visibility text not null check (visibility in ('private', 'workspace')),
+  state jsonb not null,
+  revision integer not null,
+  created_at timestamptz not null,
+  updated_at timestamptz not null,
+  created_by_user_id uuid references users(id),
+  updated_by_user_id uuid references users(id),
+  imported_from_json boolean not null default false
+)
+
+project_revisions (
+  id bigserial primary key,
+  project_id text not null references projects(id) on delete cascade,
+  revision integer not null,
+  state jsonb not null,
+  saved_at timestamptz not null,
+  saved_by_user_id uuid references users(id),
+  saved_by_email text,
+  saved_by_name text,
+  summary text not null,
+  unique(project_id, revision)
+)
+
+org_settings (
+  key text primary key,
+  value jsonb not null,
+  updated_at timestamptz not null,
+  updated_by_user_id uuid references users(id)
+)
+
+user_settings (
+  user_id uuid not null references users(id) on delete cascade,
+  key text not null,
+  value jsonb not null,
+  updated_at timestamptz not null,
+  primary key (user_id, key)
+)
+
+announcements (
+  id text primary key,
+  title text not null,
+  body text not null,
+  url text not null,
+  sort_order integer not null,
+  updated_at timestamptz not null,
+  updated_by_user_id uuid references users(id)
+)
+
+songs (
+  id text primary key,
+  title text not null,
+  author text not null,
+  lyrics text not null,
+  copyright text not null,
+  source text,
+  date_added timestamptz,
+  updated_at timestamptz not null,
+  updated_by_user_id uuid references users(id)
+)
+
+templates (
+  id text primary key,
+  name text not null,
+  built_in boolean not null,
+  template jsonb not null,
+  owner_user_id uuid references users(id),
+  visibility text not null check (visibility in ('workspace')),
+  updated_at timestamptz not null,
+  updated_by_user_id uuid references users(id)
+)
+
+fonts (
+  slug text primary key,
+  family text not null,
+  source text not null check (source in ('user', 'cache')),
+  css_url text not null,
+  file_path text,
+  metadata jsonb not null default '{}'::jsonb,
+  uploaded_at timestamptz,
+  uploaded_by_user_id uuid references users(id)
+)
+
+data_migrations (
+  id text primary key,
+  applied_at timestamptz not null,
+  details jsonb not null default '{}'::jsonb
+)
+```
+
+## JSON File Handling Plan
+
+- `projects.json`: migrate into `projects` and initial `project_revisions`. Existing projects become `visibility='workspace'` by default because they previously lived in the shared server shelf. `owner_user_id` is null unless `createdBy` / `updatedBy` can be mapped to a known user later.
+- `announcements.json`: migrate into `announcements`. Treat as workspace-level shared content for v1.
+- `settings.json`: split into `org_settings` and `user_settings`.
+  - Organization settings: church name, staff data, serving team filters, type formats, doc template, default give URL, calendar URL fallback/exclude defaults, Google Drive shared folder ID if the deployment continues using a shared Drive export connection.
+  - Per-user settings: editor display name legacy value, selected Google calendars if app integrations become per-user, personal OAuth tokens if retained.
+  - Secrets/tokens: avoid storing OAuth tokens in generic settings long term; move shared integration tokens into dedicated secure rows or keep them file-backed until the auth split is designed.
+- `song_database.json`: migrate into `songs`. Treat as workspace-level shared content for v1, because the song database is currently global.
+- `templates.json`: migrate into `templates`. Built-ins remain protected. User-created templates become workspace-visible for v1 to match current shared behavior.
+- `fonts/`: keep files on disk; insert rows in `fonts` for discoverability and audit. Migration scans existing `data/fonts/user/*` and `data/fonts/cache/*`.
+- `migrations.json`: replace with `data_migrations` in server mode; keep `migrations.json` for desktop mode.
+
+## Milestones and Atomic GitHub Issues
+
+### Milestone 1: Collaboration V1 - Server Postgres Foundation
+
+1. Add Postgres service and server environment configuration.
+2. Add Python database dependency and connection helper.
+3. Add schema migration runner and `data_migrations` table.
+4. Add storage boundary so server routes stop directly reading JSON in server mode.
+5. Add health/readiness endpoint for database-backed server mode.
+
+### Milestone 2: Collaboration V1 - JSON Data Migration
+
+6. Migrate projects JSON into Postgres with workspace visibility.
+7. Migrate settings JSON into org/user settings.
+8. Migrate announcements JSON into Postgres.
+9. Migrate song database JSON into Postgres.
+10. Migrate templates JSON into Postgres.
+11. Inventory font files into Postgres while keeping binaries on disk.
+12. Add backup, dry-run, and idempotency support for migrations.
+
+### Milestone 3: Collaboration V1 - Google Workspace Login
+
+13. Add separate app-login Google OAuth flow.
+14. Restrict login to `@visaliacrc.com`.
+15. Add signed server sessions and `/api/me`.
+16. Protect server-mode API routes behind login.
+17. Add frontend login/logout shell.
+18. Split app identity from existing Calendar/Drive integration identity.
+
+### Milestone 4: Collaboration V1 - Private and Workspace Projects
+
+19. Add owner and visibility fields to project API responses.
+20. Default new projects to private owner workspace.
+21. Add "Share to Workspace" endpoint and UI.
+22. Replace startup newest-project fallback with user-safe restore behavior.
+23. Add Files page views for My Projects and Workspace Projects.
+24. Enforce project visibility in list/load/save/delete routes.
+
+### Milestone 5: Collaboration V1 - Revision History and Conflict UX
+
+25. Make project saves transactional with optimistic revision checks.
+26. Append full revision snapshots and audit metadata on each save.
+27. Generate high-level change summaries for revision records.
+28. Add project history API and restore endpoint.
+29. Replace current conflict banner with Review latest / Save as my copy / Replace with latest.
+30. Add shared-project stale polling using authenticated user metadata.
+
+### Milestone 6: Collaboration V1 - Shared Data, Hardening, and Release
+
+31. Route announcements, songs, templates, settings, and fonts through Postgres storage in server mode.
+32. Add authorization and regression tests for all migrated APIs.
+33. Add migration tests using representative legacy JSON fixtures.
+34. Update Docker, `.env.example`, README, and architecture docs.
+35. Add an admin backup/export command for Postgres data.
+36. Run end-to-end server-mode QA with two signed-in users.
+
+## Acceptance Criteria
+
+- A user with `@visaliacrc.com` can sign in and access the server app.
+- A non-`@visaliacrc.com` Google account is rejected.
+- New projects are private to the signed-in user.
+- A private project can be shared to the workspace.
+- Workspace projects are visible and editable by every signed-in workspace user.
+- Private projects are not visible to other users.
+- Concurrent saves cannot silently overwrite another user's changes.
+- Conflict UI lets a user preserve their work as a private copy.
+- Every workspace save records who saved it, when, revision number, full snapshot, and high-level summary.
+- Existing `projects.json`, `settings.json`, `announcements.json`, `song_database.json`, `templates.json`, and font directories migrate without data loss.
+- Desktop mode still runs without Postgres and keeps local file-backed behavior.
+

--- a/index.html
+++ b/index.html
@@ -646,36 +646,38 @@
     </div>
   </div>
 
-  <!-- Full-screen designer overlay (hidden until launched) -->
-  <div id="tpl-designer-overlay" style="display:none; position:fixed; inset:0; z-index:200; background:var(--base-100,#fff); flex-direction:column;">
-    <div class="flex items-center gap-3 px-4 py-2 border-b bg-base-200" style="flex-shrink:0;">
-      <button class="btn btn-ghost btn-sm" id="tpl-designer-back">← Back</button>
-      <input class="input input-bordered input-sm flex-1 max-w-xs font-medium" id="tpl-designer-name" type="text" placeholder="Template name…" aria-label="Template name">
-      <div class="flex gap-2 ml-auto">
-        <button class="btn btn-ghost btn-sm" id="tpl-designer-export">Export</button>
-        <button class="btn btn-ghost btn-sm" id="tpl-designer-save-as">Save As…</button>
-        <button class="btn btn-primary btn-sm" id="tpl-designer-save">Save</button>
-      </div>
-    </div>
-    <div class="flex items-center gap-4 px-4 py-2 border-b bg-base-100 text-sm" id="tpl-designer-toolbar" style="flex-shrink:0; min-height:2.75rem;">
-      <span class="text-base-content/40 italic" id="tpl-toolbar-hint">Click any element in the preview to edit its formatting</span>
-    </div>
-    <div id="tpl-designer-canvas" style="flex:1; overflow-y:auto; background:#e5e7eb; display:flex; justify-content:center; padding:2rem;">
-      <!-- bulletin preview rendered here -->
-    </div>
-  </div>
 
-  <!-- Apply-to-project dialog (modal) -->
-  <div id="tpl-apply-dialog" role="dialog" aria-modal="true" aria-labelledby="tpl-apply-dialog-msg" style="display:none; position:fixed; inset:0; z-index:300; background:rgba(0,0,0,0.4); align-items:center; justify-content:center;">
-    <div class="bg-base-100 rounded-xl shadow-xl p-6 max-w-sm w-full mx-4">
-      <div class="text-base font-medium mb-4" id="tpl-apply-dialog-msg">Apply this template to the current project?</div>
-      <div class="flex gap-2 justify-end">
-        <button class="btn btn-ghost btn-sm" id="tpl-apply-cancel">Not now</button>
-        <button class="btn btn-primary btn-sm" id="tpl-apply-confirm">Apply</button>
-      </div>
+</div><!-- #page-templates -->
+
+<!-- Full-screen designer overlay (hidden until launched) -->
+<div id="tpl-designer-overlay" style="display:none; position:fixed; inset:0; z-index:200; background:var(--base-100,#fff); flex-direction:column;">
+  <div class="flex items-center gap-3 px-4 py-2 border-b bg-base-200" style="flex-shrink:0;">
+    <button class="btn btn-ghost btn-sm" id="tpl-designer-back">← Back</button>
+    <input class="input input-bordered input-sm flex-1 max-w-xs font-medium" id="tpl-designer-name" type="text" placeholder="Template name…" aria-label="Template name">
+    <div class="flex gap-2 ml-auto">
+      <button class="btn btn-ghost btn-sm" id="tpl-designer-export">Export</button>
+      <button class="btn btn-ghost btn-sm" id="tpl-designer-save-as">Save As…</button>
+      <button class="btn btn-primary btn-sm" id="tpl-designer-save">Save</button>
     </div>
   </div>
-</div><!-- #page-templates -->
+  <div class="flex items-center gap-4 px-4 py-2 border-b bg-base-100 text-sm" id="tpl-designer-toolbar" style="flex-shrink:0; min-height:2.75rem;">
+    <span class="text-base-content/40 italic" id="tpl-toolbar-hint">Click any element in the preview to edit its formatting</span>
+  </div>
+  <div id="tpl-designer-canvas" style="flex:1; overflow-y:auto; background:#e5e7eb; display:flex; justify-content:center; padding:2rem;">
+    <!-- bulletin preview rendered here -->
+  </div>
+</div>
+
+<!-- Apply-to-project dialog (modal) -->
+<div id="tpl-apply-dialog" role="dialog" aria-modal="true" aria-labelledby="tpl-apply-dialog-msg" style="display:none; position:fixed; inset:0; z-index:300; background:rgba(0,0,0,0.4); align-items:center; justify-content:center;">
+  <div class="bg-base-100 rounded-xl shadow-xl p-6 max-w-sm w-full mx-4">
+    <div class="text-base font-medium mb-4" id="tpl-apply-dialog-msg">Apply this template to the current project?</div>
+    <div class="flex gap-2 justify-end">
+      <button class="btn btn-ghost btn-sm" id="tpl-apply-cancel">Not now</button>
+      <button class="btn btn-primary btn-sm" id="tpl-apply-confirm">Apply</button>
+    </div>
+  </div>
+</div>
 
 <!-- ═══ Import Review Modal ════════════════════════════════════════════════ -->
 <dialog id="import-review-modal" class="modal">

--- a/server.py
+++ b/server.py
@@ -579,21 +579,35 @@ def parse_ical_events(text):
     return events
 
 
-def get_week_window():
-    """Return (start, end) as date objects for the upcoming Sunday–Saturday window."""
-    today = datetime.now().date()
-    dow = today.weekday()  # Monday=0, Sunday=6
-    days_until_sunday = (6 - dow) % 7  # 0 if today is Sunday
-    start = today + timedelta(days=days_until_sunday)
-    end   = start + timedelta(days=8)
+def get_week_window(svc_date_str=None):
+    """Return (start, end) as date objects for the Sunday–following-Sunday window.
+
+    If svc_date_str is provided and parseable, start is that Sunday (the service date).
+    Otherwise falls back to the next upcoming Sunday from today.
+    end is always start + 7 days (inclusive through the following Sunday).
+    """
+    start = None
+    if svc_date_str:
+        for fmt in ('%Y-%m-%d', '%B %d, %Y', '%b %d, %Y'):
+            try:
+                start = datetime.strptime(svc_date_str.strip(), fmt).date()
+                break
+            except ValueError:
+                pass
+    if start is None:
+        today = datetime.now().date()
+        dow = today.weekday()          # Monday=0, Sunday=6
+        days_until_sunday = (6 - dow) % 7  # 0 if today is Sunday
+        start = today + timedelta(days=days_until_sunday)
+    end = start + timedelta(days=7)    # through the following Sunday (inclusive)
     return start, end
 
 
-def fetch_and_parse_calendars(urls, exclude_titles):
+def fetch_and_parse_calendars(urls, exclude_titles, svc_date_str=None):
     """Fetch all iCal URLs, parse, filter, deduplicate. Returns sorted event list."""
     if not urls:
         return []
-    start_date, end_date = get_week_window()
+    start_date, end_date = get_week_window(svc_date_str)
     exclude_lower = {t.strip().lower() for t in exclude_titles}
     all_events = []
     any_success = False
@@ -671,13 +685,13 @@ def fetch_and_parse_calendars(urls, exclude_titles):
     return deduped
 
 
-def fetch_google_cal_events(auth_header, calendar_ids, exclude_titles):
+def fetch_google_cal_events(auth_header, calendar_ids, exclude_titles, svc_date_str=None):
     """Fetch this week's events from Google Calendar API for given calendar IDs.
     Returns None if any calendar returns 401/403 (signals auth failure to caller).
     Returns [] if auth succeeds but there are no events in the window.
     Returns a list of events otherwise.
     """
-    start_date, end_date = get_week_window()
+    start_date, end_date = get_week_window(svc_date_str)
     time_min = datetime.combine(start_date, datetime.min.time()).replace(tzinfo=timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
     time_max = datetime.combine(end_date,   datetime.max.time().replace(microsecond=0)).replace(tzinfo=timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
     exclude_lower = {t.strip().lower() for t in exclude_titles}
@@ -2158,20 +2172,22 @@ class Handler(http.server.SimpleHTTPRequestHandler):
                 except Exception:
                     pass
 
+            svc_date_str = params.get('date', [None])[0]
+
             # Prefer Google Calendar API if the user is connected and has selected calendars
             google_cal_ids = _read_json(SETTINGS_FILE, {}).get('googleCalendarIds', [])
             google_auth = _google_auth_header()
             if google_auth and google_cal_ids:
-                result = fetch_google_cal_events(google_auth, google_cal_ids, exclude)
+                result = fetch_google_cal_events(google_auth, google_cal_ids, exclude, svc_date_str)
                 if result is None:
                     # None means auth failure (401/403) — refresh token and retry once
                     new_auth = _refresh_google_token()
                     if new_auth:
-                        result = fetch_google_cal_events(new_auth, google_cal_ids, exclude)
+                        result = fetch_google_cal_events(new_auth, google_cal_ids, exclude, svc_date_str)
                     else:
                         result = []
             else:
-                result = fetch_and_parse_calendars(urls, exclude)
+                result = fetch_and_parse_calendars(urls, exclude, svc_date_str)
 
             if result is None:
                 payload = {'ok': False, 'events': [], 'error': 'All calendar fetches failed.'}

--- a/server.py
+++ b/server.py
@@ -741,6 +741,12 @@ def fetch_google_cal_events(auth_header, calendar_ids, exclude_titles, svc_date_
                 iso_end   = end_raw.get('dateTime')  if end_raw else None
             if not iso_start:
                 continue
+            try:
+                event_start_date = datetime.strptime(iso_start[:10], '%Y-%m-%d').date()
+            except ValueError:
+                continue
+            if event_start_date < start_date:
+                continue
             all_events.append({
                 'title':       title,
                 'start':       {'iso': iso_start, 'allDay': all_day},

--- a/src/js/calendar.js
+++ b/src/js/calendar.js
@@ -575,6 +575,7 @@ async function calFetchAll(force) {
   const params = new URLSearchParams({
     urls: JSON.stringify(urls),
     exclude: JSON.stringify(excl),
+    date: svcDate.value.trim(),
   });
 
   try {
@@ -804,9 +805,26 @@ function buildCalendarSegments(church) {
     return singleSegment('cal-empty', 'No events scheduled this week.');
   }
 
+  // Derive the window start from the service date so that multi-day events originating
+  // before that Sunday are excluded even if they span into the week.
+  let windowStart = null;
+  if (svcDate && svcDate.value) {
+    const raw = svcDate.value.trim();
+    // Force local-date parsing: ISO "YYYY-MM-DD" must use explicit constructor to
+    // avoid UTC-midnight shift; other formats (e.g. "April 27, 2026") are local by default.
+    const iso = raw.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    const d = iso ? new Date(+iso[1], +iso[2] - 1, +iso[3]) : new Date(raw);
+    if (d && !isNaN(d.getTime())) {
+      windowStart = d.getFullYear() + '-' +
+        String(d.getMonth() + 1).padStart(2, '0') + '-' +
+        String(d.getDate()).padStart(2, '0');
+    }
+  }
+
   const byDay = new Map();
   for (const ev of calEvents) {
     const dayKey = ev.start.iso.slice(0, 10);
+    if (windowStart && dayKey < windowStart) continue; // skip events starting before service Sunday
     if (!byDay.has(dayKey)) byDay.set(dayKey, []);
     byDay.get(dayKey).push(ev);
   }
@@ -920,33 +938,33 @@ function renderServingWeek(container, weekData, labelText, weekIdx) {
     return;
   }
 
-  // Group teams by service time, preserving the order they first appear
-  const timeGroups = {};
-  const timeOrder  = [];
+  // Group teams by service time. Teams with no service time are distributed to all named groups.
+  const namedGroups = {};
+  const namedOrder  = [];
+  const allTimesTeams = [];
   visibleTeams.forEach(team => {
     const key = team.serviceTime || '';
-    if (!timeGroups[key]) { timeGroups[key] = []; timeOrder.push(key); }
-    timeGroups[key].push(team);
+    if (!key) { allTimesTeams.push(team); return; }
+    if (!namedGroups[key]) { namedGroups[key] = []; namedOrder.push(key); }
+    namedGroups[key].push(team);
   });
 
-  timeOrder.forEach((svcTime, groupIdx) => {
+  namedOrder.forEach((svcTime, groupIdx) => {
+    const groupTeams = [...namedGroups[svcTime], ...allTimesTeams];
     if (groupIdx > 0) {
-      const firstTeam = timeGroups[svcTime][0];
-      const insertBeforeIdx = (weekData.teams || []).indexOf(firstTeam);
+      const insertBeforeIdx = (weekData.teams || []).indexOf(namedGroups[svcTime][0]);
       container.appendChild(makeSplitCtrlEl(makeBreakSrc('serving-split', {
         weekIdx, boundary: 'team', insertBeforeIdx,
       })));
     }
-    if (svcTime) {
-      const stLabel = document.createElement('div');
-      stLabel.className = 'serving-service-time preview-linkable';
-      stLabel.dataset.previewVolWeekIdx = weekIdx;
-      stLabel.dataset.previewVolSt      = svcTime;
-      stLabel.textContent = svcTime;
-      applyElementFmt(stLabel, getTemplateElementFmt(activeDocTemplate, 'serving_schedule', '', svcTime, 'serviceTime'));
-      container.appendChild(stLabel);
-    }
-    timeGroups[svcTime].forEach(team => {
+    const stLabel = document.createElement('div');
+    stLabel.className = 'serving-service-time preview-linkable';
+    stLabel.dataset.previewVolWeekIdx = weekIdx;
+    stLabel.dataset.previewVolSt      = svcTime;
+    stLabel.textContent = svcTime;
+    applyElementFmt(stLabel, getTemplateElementFmt(activeDocTemplate, 'serving_schedule', '', svcTime, 'serviceTime'));
+    container.appendChild(stLabel);
+    groupTeams.forEach(team => {
       const teamIdx = (weekData.teams || []).indexOf(team);
       renderServingTeam(container, team, weekIdx, teamIdx);
     });

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -27,6 +27,9 @@ import {
   deriveProjectSaveSuccess as deriveProjectSaveSuccessCore,
   deriveProjectSaveFailure as deriveProjectSaveFailureCore,
 } from './modules/projects-core.js';
+import {
+  mapPcoItemType as mapPcoItemTypeCore,
+} from './modules/pco-core.js';
 
 Object.assign(globalThis, {
   getEffectiveFmtCore,
@@ -51,6 +54,7 @@ Object.assign(globalThis, {
   buildProjectSaveRequestCore,
   deriveProjectSaveSuccessCore,
   deriveProjectSaveFailureCore,
+  mapPcoItemTypeCore,
 });
 
 export const LEGACY_SCRIPT_PATHS = [

--- a/src/js/modules/pco-core.js
+++ b/src/js/modules/pco-core.js
@@ -1,0 +1,15 @@
+export const CHILDREN_DISMISSED_TITLE = 'CHILDREN DISMISSED (AGES 3-K)';
+
+export function normalizePcoTitle(title) {
+  return String(title || '').trim().replace(/\s+/g, ' ').toUpperCase();
+}
+
+export function mapPcoItemType(attrs = {}) {
+  if (attrs.item_type === 'header') {
+    return normalizePcoTitle(attrs.title) === CHILDREN_DISMISSED_TITLE ? 'label' : 'section';
+  }
+  if (attrs.item_type === 'song') return 'song';
+  if (attrs.item_type === 'note') return 'note';
+  if (attrs.item_type === 'media') return 'media';
+  return 'label';
+}

--- a/src/js/modules/preview-core.js
+++ b/src/js/modules/preview-core.js
@@ -74,6 +74,31 @@ export function deriveChunkPlan(item, idx) {
   }
   if (safeItem.type === 'note' || safeItem.type === 'media') return [];
   if (safeItem.type === 'section') {
+    const sectionDetail = (safeItem.detail || '').trim();
+    if (sectionDetail) {
+      const paragraphs = sectionDetail.split(/\n\n+/);
+      if (paragraphs.length > 1) {
+        const forceBreakSet = new Set(Array.isArray(safeItem._forceBreakBeforeParagraph) ? safeItem._forceBreakBeforeParagraph : []);
+        const noBreakSet   = new Set(Array.isArray(safeItem._noBreakBeforeParagraph)    ? safeItem._noBreakBeforeParagraph    : []);
+        const noBreakBefore = !!safeItem._noBreakBefore;
+        const plan = [];
+        paragraphs.forEach((paragraph, paragraphIdx) => {
+          if (paragraphIdx > 0 && forceBreakSet.has(paragraphIdx)) {
+            plan.push({ renderKind: 'sentinel', forceBreak: true, paragraphBreakItemIdx: idx, paragraphBreakIdx: paragraphIdx, itemIdx: idx, sourceId: idx, section: 'oow' });
+          }
+          plan.push({
+            renderKind: 'paragraph',
+            paragraph, paragraphIdx,
+            itemIdx: idx, sourceId: idx, section: 'oow',
+            noBreakBefore: paragraphIdx === 0 ? noBreakBefore : noBreakSet.has(paragraphIdx),
+            stickyToNext: paragraphIdx === 0,
+            isFirstParagraph: paragraphIdx === 0,
+            title: (safeItem.title || '').trim(),
+          });
+        });
+        return plan;
+      }
+    }
     return [{ renderKind: 'full-item', stickyToNext: true, noBreakBefore: !!safeItem._noBreakBefore, itemIdx: idx, sourceId: idx, section: 'oow' }];
   }
 

--- a/src/js/pco.js
+++ b/src/js/pco.js
@@ -574,10 +574,14 @@ function irmRadioRow(groupName, labelText, checked, onChange) {
 }
 
 function pcoMapItemType(attrs) {
-  if (attrs.item_type === 'header') return 'section';
-  if (attrs.item_type === 'song')   return 'song';
-  if (attrs.item_type === 'note')   return 'note';
-  if (attrs.item_type === 'media')  return 'media';
+  if (typeof mapPcoItemTypeCore === 'function') return mapPcoItemTypeCore(attrs);
+  if (attrs.item_type === 'header') {
+    const title = String(attrs.title || '').trim().replace(/\s+/g, ' ').toUpperCase();
+    return title === 'CHILDREN DISMISSED (AGES 3-K)' ? 'label' : 'section';
+  }
+  if (attrs.item_type === 'song') return 'song';
+  if (attrs.item_type === 'note') return 'note';
+  if (attrs.item_type === 'media') return 'media';
   // PCO 'item' type — default to label (title-only liturgical items)
   // enrichItemsFromDb will upgrade liturgical text items to 'liturgy'
   // if they match LITURGICAL_RE and need a DB lookup.

--- a/src/js/preview.js
+++ b/src/js/preview.js
@@ -450,7 +450,7 @@ function applyPreviewLinkMeta(el, chunk) {
 // A `---` line inside song lyrics creates a forced-break sentinel between sections.
 function buildChunks(item, idx) {
   const plan = deriveChunkPlanCore(item, idx);
-  const titleKey = item.type === 'song' ? 'songTitle' : 'title';
+  const titleKey = item.type === 'section' ? 'heading' : item.type === 'song' ? 'songTitle' : 'title';
   const bodyKey = item.type === 'song' ? 'stanzaText'
     : item.type === 'liturgy' ? 'bodyParagraph'
     : 'body';
@@ -526,19 +526,30 @@ function buildChunks(item, idx) {
       });
     }
 
+    const isSectionItem = item.type === 'section';
     const wrap = document.createElement('div');
-    wrap.className = 'order-item' + (part.isFirstParagraph ? ' preview-linkable' : '');
+    wrap.className = (isSectionItem ? 'liturgy-section' : 'order-item') +
+                     (part.isFirstParagraph ? ' preview-linkable' : '');
     applyPreviewLinkMeta(wrap, { section: 'oow', itemIdx: idx, paragraphIdx: part.paragraphIdx });
     if (part.isFirstParagraph && part.title) {
       const h = document.createElement('div');
-      h.className = 'item-heading has-rule';
-      h.textContent = part.title;
-      applyElementFmt(h, getTemplateElementFmt(activeDocTemplate, 'pco_items', item.type, item.title, 'title'));
-      applyTitleFmt(h, titleFmt);
+      if (isSectionItem) {
+        h.className = 'section-heading';
+        h.textContent = part.title;
+        applyElementFmt(h, getTemplateElementFmt(activeDocTemplate, 'pco_items', item.type, item.title, 'heading'));
+        if (titleFmt.titleColor) h.style.color = titleFmt.titleColor;
+        if (titleFmt.titleAlign) h.style.textAlign = titleFmt.titleAlign;
+      } else {
+        h.className = 'item-heading has-rule';
+        h.textContent = part.title;
+        applyElementFmt(h, getTemplateElementFmt(activeDocTemplate, 'pco_items', item.type, item.title, 'title'));
+        applyTitleFmt(h, titleFmt);
+      }
       wrap.appendChild(h);
     }
     const body = document.createElement('div');
     body.className = 'item-body';
+    if (isSectionItem) body.style.marginTop = '0.3rem';
     applyElementFmt(body, getTemplateElementFmt(activeDocTemplate, 'pco_items', item.type, item.title, bodyKey));
     applyBodyFmt(body, bodyFmt);
     renderBodyText(body, part.paragraph, true);
@@ -548,6 +559,7 @@ function buildChunks(item, idx) {
       sourceId: part.sourceId,
       els: [wrap],
       noBreakBefore: !!part.noBreakBefore,
+      stickyToNext: !!part.stickyToNext,
       itemIdx: part.itemIdx ?? null,
       paragraphIdx: part.paragraphIdx ?? null,
     });
@@ -1066,74 +1078,149 @@ function renderPreview() {
   function renderServingZone() {
     if (!(servingSchedule && optVolunteers.checked)) return;
 
+    const AVAIL_H = Math.round((getPageDims().h - 0.35 - 0.45 - (optFooter.checked ? 0.55 : 0)) * 96);
     const srvChunks = buildServingChunks(servingSchedule, servingTeamFilter, volTeamFilter);
+    if (srvChunks.length === 0) return;
 
-    // Pack chunks into pages[] using pre-resolved forceBreak flags.
-    // pageSources[i] explains why serving page (i+1) started.
-    const pages = [[]];
-    const pageSources = [];
-    srvChunks.forEach(chunk => {
-      if (chunk.forceBreak && pages[pages.length - 1].length > 0) {
-        const prevChunk = pages[pages.length - 1][pages[pages.length - 1].length - 1];
-        if (prevChunk && prevChunk.servingWeekIdx === chunk.servingWeekIdx) {
-          pageSources.push(makeBreakSrc('serving-team', {
-            weekIdx: chunk.servingWeekIdx,
-            teamBreakIdx: chunk.servingTeamBreakIdx,
-          }));
-        } else {
-          pageSources.push(makeBreakSrc('serving-week', { weekIdx: chunk.servingWeekIdx }));
-        }
-        pages.push([]);
+    let servingStarted = false;
+
+    function addServingPage(el, breakSrc) {
+      const contentH = measureBottomContent(el);
+      const pg = document.createElement('div');
+      pg.className = 'booklet-page';
+      pg.appendChild(el);
+      if (optFooter.checked) {
+        const footer = document.createElement('div');
+        footer.className = 'page-footer';
+        footer.innerHTML = `<span>${esc(church)}</span><span>${esc(date)}</span>`;
+        pg.appendChild(footer);
       }
-      pages[pages.length - 1].push(chunk);
-    });
-
-    pages.forEach((pageChunks, pi) => {
-      const servingContent = document.createElement('div');
-      servingContent.classList.add('preview-linkable');
-      applyPreviewLinkMeta(servingContent, { section: 'serving' });
-      pageChunks.forEach((chunk, itemIdx) => {
-        if (itemIdx > 0) {
-          const prevChunk = pageChunks[itemIdx - 1];
-          const isSameWeek = prevChunk.servingWeekIdx === chunk.servingWeekIdx;
-          const firstTeam = isSameWeek ? (chunk.servingSegTeams || []).find(t => t && t.type !== 'page-break') : null;
-          const insertBeforeIdx = firstTeam ? (chunk.servingWeek.teams || []).indexOf(firstTeam) : -1;
-          const ctrl = makeSplitCtrlEl(makeBreakSrc('serving-split', {
-            weekIdx: chunk.servingWeekIdx,
-            boundary: isSameWeek ? 'team' : 'week',
-            insertBeforeIdx: isSameWeek ? insertBeforeIdx : '',
-          }));
-          servingContent.appendChild(ctrl);
-        }
-        renderServingWeek(servingContent, { ...chunk.servingWeek, teams: chunk.servingSegTeams }, chunk.servingLabel, chunk.servingWeekIdx);
-        chunk.els = [servingContent];
-      });
-      if (pi === 0) {
-        appendBottomSection(servingContent, 'serving');
+      if (lastRenderedPageEl && breakSrc) {
+        const ctrl = makeBreakCtrlEl(breakSrc);
+        lastRenderedPageEl.after(ctrl);
+        ctrl.after(pg);
+      } else if (lastRenderedPageEl) {
+        lastRenderedPageEl.after(pg);
       } else {
-        // Continuation pages always get their own page (no merge toggle)
-        const contentH = measureBottomContent(servingContent);
-        const pg = document.createElement('div');
-        pg.className = 'booklet-page';
-        pg.appendChild(servingContent);
-        if (optFooter.checked) {
-          const footer = document.createElement('div');
-          footer.className = 'page-footer';
-          footer.innerHTML = `<span>${esc(church)}</span><span>${esc(date)}</span>`;
-          pg.appendChild(footer);
-        }
-        if (lastRenderedPageEl) {
-          const src = pageSources[pi - 1] || makeBreakSrc('serving-team', {});
-          const ctrl = makeBreakCtrlEl(src);
-          lastRenderedPageEl.after(ctrl);
-          ctrl.after(pg);
-        } else previewPane.appendChild(pg);
-        lastRenderedPageEl = pg;
-        lastPageUsedH = contentH;
-        lastRenderedBinding = 'serving_schedule';
+        previewPane.appendChild(pg);
       }
+      lastRenderedPageEl = pg;
+      lastPageUsedH = contentH;
+      lastRenderedBinding = 'serving_schedule';
+    }
+
+    srvChunks.forEach(chunk => {
+      const weekIdx = chunk.servingWeekIdx;
+      const visibleTeams = (chunk.servingSegTeams || []).filter(
+        t => t.type !== 'page-break' &&
+             servingTeamFilter[t.name] !== false &&
+             volTeamFilter['w' + weekIdx + ':' + (t.serviceTime || '') + ':' + t.name] !== false
+      );
+      if (visibleTeams.length === 0) return;
+
+      const hasServiceTimes = visibleTeams.some(t => t.serviceTime);
+
+      if (!hasServiceTimes) {
+        // Flat-list (no service times): render whole chunk as one block with existing split controls
+        const servingContent = document.createElement('div');
+        servingContent.classList.add('preview-linkable');
+        applyPreviewLinkMeta(servingContent, { section: 'serving' });
+        renderServingWeek(servingContent, { ...chunk.servingWeek, teams: chunk.servingSegTeams }, chunk.servingLabel, weekIdx);
+
+        if (!servingStarted) {
+          chunk.forceBreak ? addServingPage(servingContent, null) : appendBottomSection(servingContent, 'serving');
+          servingStarted = true;
+        } else if (chunk.forceBreak) {
+          const src = chunk.servingTeamBreakIdx !== null
+            ? makeBreakSrc('serving-team', { weekIdx, teamBreakIdx: chunk.servingTeamBreakIdx })
+            : makeBreakSrc('serving-week', { weekIdx });
+          addServingPage(servingContent, src);
+        } else {
+          const contentH = measureBottomContent(servingContent);
+          const splitCtrl = makeSplitCtrlEl(makeBreakSrc('serving-split', { weekIdx, boundary: 'week', insertBeforeIdx: '' }));
+          if (lastRenderedPageEl !== null && lastPageUsedH + contentH <= AVAIL_H) {
+            lastRenderedPageEl.appendChild(splitCtrl);
+            lastRenderedPageEl.appendChild(servingContent);
+            lastPageUsedH += contentH;
+          } else {
+            addServingPage(servingContent, null);
+          }
+        }
+        return;
+      }
+
+      // Group by service time. Teams with no service time are distributed to all named groups.
+      const namedGroups = {};
+      const namedOrder  = [];
+      const allTimesTeams = [];
+      visibleTeams.forEach(team => {
+        const key = team.serviceTime || '';
+        if (!key) { allTimesTeams.push(team); return; }
+        if (!namedGroups[key]) { namedGroups[key] = []; namedOrder.push(key); }
+        namedGroups[key].push(team);
+      });
+
+      namedOrder.forEach((svcTime, groupIdx) => {
+        const isFirstGroup = groupIdx === 0;
+        const groupTeams = [...namedGroups[svcTime], ...allTimesTeams];
+
+        const groupEl = document.createElement('div');
+        groupEl.classList.add('preview-linkable');
+        applyPreviewLinkMeta(groupEl, { section: 'serving' });
+
+        if (isFirstGroup) {
+          const wLabel = document.createElement('div');
+          wLabel.className = 'serving-week-label';
+          wLabel.textContent = chunk.servingLabel;
+          applyElementFmt(wLabel, getTemplateElementFmt(activeDocTemplate, 'serving_schedule', '', chunk.servingLabel, 'weekHeading'));
+          groupEl.appendChild(wLabel);
+        }
+
+        if (svcTime) {
+          const stLabel = document.createElement('div');
+          stLabel.className = 'serving-service-time preview-linkable';
+          stLabel.dataset.previewVolWeekIdx = weekIdx;
+          stLabel.dataset.previewVolSt = svcTime;
+          stLabel.textContent = svcTime;
+          applyElementFmt(stLabel, getTemplateElementFmt(activeDocTemplate, 'serving_schedule', '', svcTime, 'serviceTime'));
+          groupEl.appendChild(stLabel);
+        }
+
+        groupTeams.forEach(team => {
+          const teamIdx = (chunk.servingWeek.teams || []).indexOf(team);
+          renderServingTeam(groupEl, team, weekIdx, teamIdx);
+        });
+
+        if (!servingStarted) {
+          chunk.forceBreak ? addServingPage(groupEl, null) : appendBottomSection(groupEl, 'serving');
+          servingStarted = true;
+        } else if (isFirstGroup && chunk.forceBreak) {
+          const src = chunk.servingTeamBreakIdx !== null
+            ? makeBreakSrc('serving-team', { weekIdx, teamBreakIdx: chunk.servingTeamBreakIdx })
+            : makeBreakSrc('serving-week', { weekIdx });
+          addServingPage(groupEl, src);
+        } else {
+          // Auto-break: fit on current page or overflow to new page
+          const contentH = measureBottomContent(groupEl);
+          const firstNamedTeam = namedGroups[svcTime][0];
+          const insertBeforeIdx = (chunk.servingWeek.teams || []).indexOf(firstNamedTeam);
+          const splitCtrl = makeSplitCtrlEl(makeBreakSrc('serving-split', {
+            weekIdx,
+            boundary: isFirstGroup ? 'week' : 'team',
+            insertBeforeIdx: isFirstGroup ? '' : insertBeforeIdx,
+          }));
+          if (lastRenderedPageEl !== null && lastPageUsedH + contentH <= AVAIL_H) {
+            lastRenderedPageEl.appendChild(splitCtrl);
+            lastRenderedPageEl.appendChild(groupEl);
+            lastPageUsedH += contentH;
+          } else {
+            addServingPage(groupEl, null);
+          }
+        }
+      });
     });
-    if (pages.some(pageChunks => pageChunks.length > 0)) lastRenderedBinding = 'serving_schedule';
+
+    if (servingStarted) lastRenderedBinding = 'serving_schedule';
   }
 
   function renderCalendarZone() {

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -802,7 +802,11 @@ async function buildPrintDocHtml(pagesHtml, title) {
   const safeTitle = escAttr(title || 'Bulletin');
   const { w, h } = getPageDims();
   const cssVars = activeDocTemplate.cssVars || {};
-  const pdfFontSans = cssVars.fontFamily || DEFAULT_TEMPLATE_CSS_VARS.fontFamily;
+  // Use the template font family but always append a reliable cross-platform
+  // fallback stack — system-ui / custom Google Fonts may not resolve in
+  // headless Chrome's file:// context (especially on Linux/Docker).
+  const templateFont = cssVars.fontFamily || DEFAULT_TEMPLATE_CSS_VARS.fontFamily;
+  const pdfFontSans  = `${templateFont}, Arial, Helvetica, sans-serif`;
   const pdfPrimary = cssVars.primary || cssVars.text || DEFAULT_TEMPLATE_CSS_VARS.primary;
   const pdfMuted = cssVars.muted || DEFAULT_TEMPLATE_CSS_VARS.muted;
   const pdfAccent = cssVars.accent || DEFAULT_TEMPLATE_CSS_VARS.accent;

--- a/src/js/state.js
+++ b/src/js/state.js
@@ -164,11 +164,27 @@ function applyDocTemplate() {
   syncTemplateFontLinks(activeDocTemplate);
   document.documentElement.style.setProperty('--doc-page-w', w + 'in');
   document.documentElement.style.setProperty('--doc-page-h', h + 'in');
-  document.documentElement.style.setProperty('--font-sans', cssVars.fontFamily || DEFAULT_TEMPLATE_CSS_VARS.fontFamily);
-  document.documentElement.style.setProperty('--text', cssVars.primary || cssVars.text || DEFAULT_TEMPLATE_CSS_VARS.primary);
-  document.documentElement.style.setProperty('--muted', cssVars.muted || DEFAULT_TEMPLATE_CSS_VARS.muted);
-  document.documentElement.style.setProperty('--accent', cssVars.accent || DEFAULT_TEMPLATE_CSS_VARS.accent);
-  document.documentElement.style.setProperty('--border', cssVars.border || DEFAULT_TEMPLATE_CSS_VARS.border);
+  const fontSans = cssVars.fontFamily || DEFAULT_TEMPLATE_CSS_VARS.fontFamily;
+  const primary  = cssVars.primary || cssVars.text || DEFAULT_TEMPLATE_CSS_VARS.primary;
+  const muted    = cssVars.muted   || DEFAULT_TEMPLATE_CSS_VARS.muted;
+  const accent   = cssVars.accent  || DEFAULT_TEMPLATE_CSS_VARS.accent;
+  const border   = cssVars.border  || DEFAULT_TEMPLATE_CSS_VARS.border;
+  const bg       = cssVars.background || '#ffffff';
+  // Old variable names — used by preview.css, print.css, and compat.css legacy selectors
+  document.documentElement.style.setProperty('--font-sans', fontSans);
+  document.documentElement.style.setProperty('--text',      primary);
+  document.documentElement.style.setProperty('--muted',     muted);
+  document.documentElement.style.setProperty('--accent',    accent);
+  document.documentElement.style.setProperty('--border',    border);
+  // New --ui-* variable names — used by compat.css body/chrome styles (post-Tailwind migration)
+  document.documentElement.style.setProperty('--ui-font',     fontSans);
+  document.documentElement.style.setProperty('--ui-ink',      primary);
+  document.documentElement.style.setProperty('--ui-muted',    muted);
+  document.documentElement.style.setProperty('--ui-accent',   accent);
+  document.documentElement.style.setProperty('--ui-border',   border);
+  document.documentElement.style.setProperty('--ui-bg',       bg);
+  document.documentElement.style.setProperty('--ui-surface',  bg);
+  document.documentElement.style.setProperty('--ui-surface-2', bg);
   // Inject @page size — CSS variables cannot be used inside @page size
   let pageStyle = document.getElementById('doc-page-style');
   if (!pageStyle) {

--- a/tests/pco-core.spec.js
+++ b/tests/pco-core.spec.js
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { mapPcoItemType } from '../src/js/modules/pco-core.js';
+
+describe('PCO item mapping', () => {
+  it('maps the children dismissed header to a label', () => {
+    expect(mapPcoItemType({
+      item_type: 'header',
+      title: 'CHILDREN DISMISSED (AGES 3-K)',
+    })).toBe('label');
+  });
+
+  it('keeps other PCO headers as section headers', () => {
+    expect(mapPcoItemType({
+      item_type: 'header',
+      title: 'WORD',
+    })).toBe('section');
+  });
+});

--- a/tests/test_server_utils.py
+++ b/tests/test_server_utils.py
@@ -7,7 +7,7 @@ import os
 import sys
 import pytest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 # Add project root so server.py can be imported without starting the server
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -206,6 +206,37 @@ class TestUnescapeIcal:
 
     def test_no_escapes_unchanged(self):
         assert server.unescape_ical("plain text") == "plain text"
+
+
+class TestGoogleCalendarFetch:
+    def test_filters_multiday_events_that_start_before_service_date(self):
+        resp = MagicMock()
+        resp.read.return_value = json.dumps({
+            "items": [
+                {
+                    "summary": "GEMS Campout",
+                    "start": {"date": "2026-05-01"},
+                    "end": {"date": "2026-05-04"},
+                },
+                {
+                    "summary": "Single Morning Worship Service",
+                    "start": {"dateTime": "2026-05-03T09:30:00-07:00"},
+                    "end": {"dateTime": "2026-05-03T10:30:00-07:00"},
+                },
+            ]
+        }).encode()
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=resp):
+            events = server.fetch_google_cal_events(
+                "Bearer token",
+                ["primary"],
+                [],
+                "2026-05-03",
+            )
+
+        assert [event["title"] for event in events] == ["Single Morning Worship Service"]
 
 
 # ── _parse_list_env ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **#189** — Restore reliable PDF font fallback (append `Arial, Helvetica, sans-serif` to template font stack) and sync `--ui-*` CSS vars alongside legacy `--font-sans`/`--text`/etc. so headless Chrome picks up correct colors
- **Calendar** — Anchor the week window to the service date (via `?date=` param) so carryover multi-day events that started before Sunday are filtered out, both server-side and client-side
- **Serving schedule** — Rewrite rendering so teams with no service time are distributed into all named service-time groups; auto-fit groups onto current page before creating a new one
- **PCO import** — Map the "CHILDREN DISMISSED (AGES 3-K)" PCO header to `label` type instead of `section` so it doesn't render as a section heading

## Test plan

- [ ] Generate a PDF and verify font and colors render correctly (no fallback gray/system font)
- [ ] With a service date set, confirm multi-day events that started before that Sunday do not appear in the calendar section
- [ ] Verify serving schedule with multiple service times lays out correctly, with all-times teams appearing under each service time group
- [ ] Import a PCO plan containing "CHILDREN DISMISSED (AGES 3-K)" and confirm it renders as a label, not a section heading
- [ ] Run `npx vitest run` — new `pco-core.spec.js` tests pass
- [ ] Run `pytest tests/test_server_utils.py` — new `TestGoogleCalendarFetch` test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)