### PR TITLE
fix: derive font picker labels from DEFAULT_TEMPLATE_CSS_VARS

### DIFF
--- a/docs/superpowers/plans/2026-04-27-font-picker-default-label.md
+++ b/docs/superpowers/plans/2026-04-27-font-picker-default-label.md
@@ -1,0 +1,129 @@
+# Font Picker Default Label Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the hardcoded `(default)` and `system-ui` strings in the template designer's font pickers with values derived from `DEFAULT_TEMPLATE_CSS_VARS` so the UI accurately reflects the font that will actually render.
+
+**Architecture:** Two targeted edits in `src/js/templates.js`. The element-level font picker computes a label from the effective document font at render time. The document-level font picker replaces a hardcoded `'system-ui'` fallback with `DEFAULT_TEMPLATE_CSS_VARS.fontFamily`. No data model changes — saving `''` (no override) remains unchanged.
+
+**Tech Stack:** Vanilla JS, no bundler. `DEFAULT_TEMPLATE_CSS_VARS` is a global defined in `src/js/state.js`, available to `templates.js` at runtime. Tests run with `npm test` (Vitest).
+
+---
+
+## File Map
+
+| File | Action | What changes |
+|------|--------|-------------|
+| `src/js/templates.js` | Modify line 1497 | `|| 'system-ui'` → `|| DEFAULT_TEMPLATE_CSS_VARS.fontFamily` |
+| `src/js/templates.js` | Modify line 1533 | Hardcoded `'(default)'` label → dynamic `(default: Arial)` label |
+
+No new files. No new modules. Both changes are in the same rendering pass of the template designer toolbar.
+
+---
+
+## Task 1: Fix the document-level font picker fallback
+
+The document-level font picker (shown in the template toolbar when no element is selected) currently falls back to the hardcoded string `'system-ui'` when the template has no `cssVars.fontFamily`. It should fall back to `DEFAULT_TEMPLATE_CSS_VARS.fontFamily` to stay in sync with the actual default.
+
+**Files:**
+- Modify: `src/js/templates.js:1497`
+
+- [ ] **Step 1: Open `src/js/templates.js` and find line 1497**
+
+The current code looks like this:
+
+```js
+    // Font cluster
+    const fontPicker = makeFontSelect(designerFontOptions(), _editingTemplate.cssVars?.fontFamily || 'system-ui', val => {
+      _editingTemplate.cssVars = _editingTemplate.cssVars || {};
+      _editingTemplate.cssVars.fontFamily = val;
+      markDesignerDirty();
+    });
+```
+
+- [ ] **Step 2: Replace `|| 'system-ui'` with `|| DEFAULT_TEMPLATE_CSS_VARS.fontFamily`**
+
+```js
+    // Font cluster
+    const fontPicker = makeFontSelect(designerFontOptions(), _editingTemplate.cssVars?.fontFamily || DEFAULT_TEMPLATE_CSS_VARS.fontFamily, val => {
+      _editingTemplate.cssVars = _editingTemplate.cssVars || {};
+      _editingTemplate.cssVars.fontFamily = val;
+      markDesignerDirty();
+    });
+```
+
+- [ ] **Step 3: Run the test suite to confirm no regressions**
+
+```bash
+npm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Manually verify in the browser**
+
+```bash
+python3 server.py
+```
+
+Open `http://localhost:8080`, go to the Template Designer, and open or create any template. With no font explicitly set, the document-level font picker in the top toolbar should now show `Arial` (not `system-ui`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/js/templates.js
+git commit -m "fix: use DEFAULT_TEMPLATE_CSS_VARS fallback in document-level font picker"
+```
+
+---
+
+## Task 2: Fix the element-level font picker label
+
+The element-level font picker (shown when an element like "Label Items / body" is selected) hardcodes `'(default)'` as the label for the no-override option. It should read the effective document font and show `(default: Arial)` — or whatever the template font is if one is set.
+
+**Files:**
+- Modify: `src/js/templates.js:1533`
+
+- [ ] **Step 1: Open `src/js/templates.js` and find line 1533**
+
+The current code looks like this:
+
+```js
+  // Font cluster
+  const fontPicker = makeFontSelect([{ value: '', label: '(default)' }].concat(designerFontOptions()), fmt.fontFamily || '', val => updateSelectedFmt('fontFamily', val));
+  const sizePicker = makeSizePicker(fmt.size || '', val => updateSelectedFmt('size', val));
+  toolbar.appendChild(toolbarCluster('Font', [fontPicker, sizePicker]));
+```
+
+- [ ] **Step 2: Compute the effective document font name and use it in the label**
+
+```js
+  // Font cluster
+  const docFont = (_editingTemplate.cssVars?.fontFamily || DEFAULT_TEMPLATE_CSS_VARS.fontFamily).split(',')[0].trim();
+  const fontPicker = makeFontSelect([{ value: '', label: `(default: ${docFont})` }].concat(designerFontOptions()), fmt.fontFamily || '', val => updateSelectedFmt('fontFamily', val));
+  const sizePicker = makeSizePicker(fmt.size || '', val => updateSelectedFmt('size', val));
+  toolbar.appendChild(toolbarCluster('Font', [fontPicker, sizePicker]));
+```
+
+`_editingTemplate` is the template currently open in the designer. `DEFAULT_TEMPLATE_CSS_VARS` is the global from `state.js`. `.split(',')[0].trim()` extracts the first font name — `Arial` from `Arial, Helvetica, sans-serif`, or `Open Sans` from a Google Font value.
+
+- [ ] **Step 3: Run the test suite**
+
+```bash
+npm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Manually verify in the browser**
+
+Open `http://localhost:8080`, go to the Template Designer. Click any element (e.g. "Label Items / body"). The FONT picker should now show `(default: Arial)` when no font override is set.
+
+Then set a custom template font (e.g. Open Sans) via the document-level font picker in the toolbar. Click an element that has no font override. The FONT picker should now show `(default: Open Sans)`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/js/templates.js
+git commit -m "fix: show effective default font name in element-level font picker label"
+```

--- a/docs/superpowers/specs/2026-04-27-font-picker-default-label-design.md
+++ b/docs/superpowers/specs/2026-04-27-font-picker-default-label-design.md
@@ -1,0 +1,78 @@
+# Design: Font Picker "default" Label Shows Actual Font Name
+
+**Date:** 2026-04-27
+**Status:** Approved
+
+---
+
+## Problem
+
+The template designer's element-level font picker shows `(default)` when no font override is set for an element. After the locked default template was changed to use `Arial, Helvetica, sans-serif` instead of `system-ui`, the label still says `(default)` — giving users no indication of what font will actually render.
+
+Additionally, the document-level font picker (the template-wide font selector in the toolbar) falls back to the hardcoded string `'system-ui'` when no template font is configured, rather than reading from `DEFAULT_TEMPLATE_CSS_VARS`. This means it can drift out of sync if the default ever changes again.
+
+---
+
+## Solution
+
+### 1. Element-level font picker — dynamic label
+
+In `src/js/templates.js` (around line 1533), replace the hardcoded `'(default)'` label with one computed from the effective document font at render time:
+
+```js
+const docFont = (_editingTemplate.cssVars?.fontFamily || DEFAULT_TEMPLATE_CSS_VARS.fontFamily)
+  .split(',')[0].trim();
+const fontPicker = makeFontSelect(
+  [{ value: '', label: `(default: ${docFont})` }].concat(designerFontOptions()),
+  fmt.fontFamily || '',
+  val => updateSelectedFmt('fontFamily', val)
+);
+```
+
+- Shows `(default: Arial)` when no template font is set
+- Shows `(default: Open Sans)` when the template uses a custom Google Font
+- Selecting `(default: Arial)` still saves `''` (no override) — no data model change
+
+### 2. Document-level font picker — remove hardcoded `'system-ui'` fallback
+
+In `src/js/templates.js` (around line 1497), replace `|| 'system-ui'` with `|| DEFAULT_TEMPLATE_CSS_VARS.fontFamily`:
+
+```js
+const fontPicker = makeFontSelect(
+  designerFontOptions(),
+  _editingTemplate.cssVars?.fontFamily || DEFAULT_TEMPLATE_CSS_VARS.fontFamily,
+  val => {
+    _editingTemplate.cssVars = _editingTemplate.cssVars || {};
+    _editingTemplate.cssVars.fontFamily = val;
+    markDesignerDirty();
+  }
+);
+```
+
+---
+
+## Scope
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `src/js/templates.js` | Two targeted edits — element-level picker label (line ~1533) and document-level picker fallback (line ~1497) |
+
+### No changes to
+
+- Template data model — `''` (no override) continues to mean "inherit from document"
+- `makeFontSelect` function — label generation logic is unchanged
+- `DEFAULT_TEMPLATE_CSS_VARS` — already updated in the previous fix
+- Any server-side code
+
+---
+
+## Behavior after the change
+
+| Scenario | Before | After |
+|----------|--------|-------|
+| Element picker, no template font set | `(default)` | `(default: Arial)` |
+| Element picker, template font = Open Sans | `(default)` | `(default: Open Sans)` |
+| Document picker, no template font set | selects `system-ui` | selects `Arial` |
+| Saving element with no override | saves `''` | saves `''` (unchanged) |

--- a/src/js/templates.js
+++ b/src/js/templates.js
@@ -1494,7 +1494,7 @@ function renderDesignerToolbar() {
     toolbar.appendChild(toolbarSep());
 
     // Font cluster
-    const fontPicker = makeFontSelect(designerFontOptions(), _editingTemplate.cssVars?.fontFamily || 'system-ui', val => {
+    const fontPicker = makeFontSelect(designerFontOptions(), _editingTemplate.cssVars?.fontFamily || DEFAULT_TEMPLATE_CSS_VARS.fontFamily, val => {
       _editingTemplate.cssVars = _editingTemplate.cssVars || {};
       _editingTemplate.cssVars.fontFamily = val;
       markDesignerDirty();
@@ -1530,7 +1530,8 @@ function renderDesignerToolbar() {
   toolbar.appendChild(toolbarSep());
 
   // Font cluster
-  const fontPicker = makeFontSelect([{ value: '', label: '(default)' }].concat(designerFontOptions()), fmt.fontFamily || '', val => updateSelectedFmt('fontFamily', val));
+  const docFont = (_editingTemplate.cssVars?.fontFamily || DEFAULT_TEMPLATE_CSS_VARS.fontFamily).split(',')[0].trim();
+  const fontPicker = makeFontSelect([{ value: '', label: `(default: ${docFont})` }].concat(designerFontOptions()), fmt.fontFamily || '', val => updateSelectedFmt('fontFamily', val));
   const sizePicker = makeSizePicker(fmt.size || '', val => updateSelectedFmt('size', val));
   toolbar.appendChild(toolbarCluster('Font', [fontPicker, sizePicker]));
 


### PR DESCRIPTION
## Summary

- Document-level font picker fell back to hardcoded 'system-ui'; now uses DEFAULT_TEMPLATE_CSS_VARS.fontFamily (Arial) so the toolbar accurately reflects the actual default font
- Element-level font picker showed a plain '(default)' label; now shows '(default: Arial)' — or the template custom font if one is set — derived from the same source of truth

## Test Plan

- [ ] Open the Template Designer with a template that has no explicit font set — document-level font picker should show Arial (not system-ui)
- [ ] Click any element with no font override — element-level font picker should show (default: Arial)
- [ ] Set a custom document font (e.g. Open Sans) via the toolbar picker, then click an element with no override — picker should update to (default: Open Sans)
- [ ] All automated tests pass (npm test)

Generated with Claude Code (https://claude.com/claude-code)