### PR TITLE
fix(templates): make Volunteer Roles elements selectable in Template Designer

### DIFF
--- a/src/js/preview.js
+++ b/src/js/preview.js
@@ -1377,6 +1377,7 @@ function renderPreview() {
           qrImg.alt = 'QR Code';
           qrImg.width = 68; qrImg.height = 68;
           qrWrap.appendChild(qrImg);
+          applyElementFmt(qrWrap, getTemplateElementFmt(activeDocTemplate, 'volunteer_roles', '', role.title || '', 'url'));
           card.appendChild(qrWrap);
         }
 
@@ -1384,6 +1385,7 @@ function renderPreview() {
           const t = document.createElement('h3');
           t.className = 'vr-entry-title';
           t.textContent = role.title;
+          applyElementFmt(t, getTemplateElementFmt(activeDocTemplate, 'volunteer_roles', '', role.title, 'title'));
           card.appendChild(t);
         }
 
@@ -1391,6 +1393,7 @@ function renderPreview() {
           const b = document.createElement('div');
           b.className = 'vr-entry-body';
           renderBodyText(b, role.body, true);
+          applyElementFmt(b, getTemplateElementFmt(activeDocTemplate, 'volunteer_roles', '', role.title || '', 'body'));
           card.appendChild(b);
         }
 

--- a/src/js/templates.js
+++ b/src/js/templates.js
@@ -966,7 +966,7 @@ function renderDesignerCanvas() {
 }
 
 function inferCanvasElement(target) {
-  const el = target.closest('.cover-church,.cover-title,.cover-date,.ann-item-heading,.ann-body,.ann-qr-wrap,.section-heading,.item-heading,.item-body,.song-copyright,.cal-day-heading,.cal-event-title,.cal-event-time,.cal-event-loc,.serving-week-label,.serving-service-time,.serving-team-name,.serving-role,.serving-row span:not(.serving-role),.sname,.srole,.semail');
+  const el = target.closest('.cover-church,.cover-title,.cover-date,.ann-item-heading,.ann-body,.ann-qr-wrap,.section-heading,.item-heading,.item-body,.song-copyright,.cal-day-heading,.cal-event-title,.cal-event-time,.cal-event-loc,.serving-week-label,.serving-service-time,.serving-team-name,.serving-role,.serving-row span:not(.serving-role),.vr-entry-title,.vr-entry-body,.vr-entry-url,.sname,.srole,.semail');
   if (!el) return null;
   const text = (el.textContent || '').trim();
 
@@ -998,6 +998,9 @@ function inferCanvasElement(target) {
   if (el.classList.contains('serving-team-name')) return { el, binding: 'serving_schedule', itemType: '', title: text, elementKey: 'teamName' };
   if (el.classList.contains('serving-role')) return { el, binding: 'serving_schedule', itemType: '', title: text.replace(/:\s*$/, ''), elementKey: 'positionLabel' };
   if (el.closest('.serving-row')) return { el, binding: 'serving_schedule', itemType: '', title: el.closest('.serving-row')?.querySelector('.serving-role')?.textContent?.replace(/:\s*$/, '') || '', elementKey: 'volunteerName' };
+  if (el.classList.contains('vr-entry-title')) return { el, binding: 'volunteer_roles', itemType: '', title: text, elementKey: 'title' };
+  if (el.classList.contains('vr-entry-body')) return { el, binding: 'volunteer_roles', itemType: '', title: nearestVolunteerRoleTitle(el), elementKey: 'body' };
+  if (el.classList.contains('vr-entry-url')) return { el, binding: 'volunteer_roles', itemType: '', title: nearestVolunteerRoleTitle(el), elementKey: 'url' };
   if (el.classList.contains('sname')) return { el, binding: 'staff', itemType: '', title: text, elementKey: 'staffName' };
   if (el.classList.contains('srole')) return { el, binding: 'staff', itemType: '', title: closestStaffName(el), elementKey: 'staffRole' };
   if (el.classList.contains('semail')) return { el, binding: 'staff', itemType: '', title: closestStaffName(el), elementKey: 'staffEmail' };
@@ -1006,6 +1009,10 @@ function inferCanvasElement(target) {
 
 function nearestAnnouncementTitle(el) {
   return el.parentElement?.querySelector('.ann-item-heading')?.textContent?.trim() || '';
+}
+
+function nearestVolunteerRoleTitle(el) {
+  return el.closest('.vr-entry')?.querySelector('.vr-entry-title')?.textContent?.trim() || '';
 }
 
 function nearestOowTitle(el) {
@@ -1044,6 +1051,9 @@ const TPL_SELECTABLE_SELECTOR = [
   '.serving-team-name',
   '.serving-role',
   '.serving-row span:not(.serving-role)',
+  '.vr-entry-title',
+  '.vr-entry-body',
+  '.vr-entry-url',
   '.sname',
   '.srole',
   '.semail'


### PR DESCRIPTION
## Summary

Two distinct bugs prevented the Template Designer from editing Volunteer Roles elements. Both are required for the panel-to-DOM contract to work; verified together by a single browser test.

### Bug 1 — Selection wiring missing (commit `966c512`)
The Designer's [`inferCanvasElement()`](src/js/templates.js#L968) and [`TPL_SELECTABLE_SELECTOR`](src/js/templates.js#L1027) didn't include the preview classes emitted by [`renderVolunteerRolesZone()`](src/js/preview.js#L1303): `.vr-entry-title`, `.vr-entry-body`, `.vr-entry-url`. Clicking a volunteer role no-op'd: the per-element toolbar never appeared.

Added the three classes to both selectors plus three matching `classList.contains(...)` branches returning `{ binding: 'volunteer_roles', elementKey }` and a `nearestVolunteerRoleTitle()` helper (parallel to `nearestAnnouncementTitle`, `closestStaffName`).

### Bug 2 — Renderer ignored per-element fmt overrides (commit `2f41347`)
`renderVolunteerRolesZone()` built each `.vr-entry-*` element but never called `applyElementFmt(el, getTemplateElementFmt(...))` — every other zone does. Without that call, panel changes are persisted in `zone.elements[elementKey]` but never reach the rendered DOM, so selecting the title and changing its color did nothing visible.

Added the missing calls for title / body / url. Now matches the cover / announcements / calendar / serving / staff renderers.

## Browser contract test (PASS, was FAIL before commit 2)

For each of `.vr-entry-title`, `.vr-entry-body`, and `.sname` (control), the test:

1. Dispatches a real bubbling click on the canvas element.
2. Asserts the per-element toolbar (Font / Text / Color / Layout / Style clusters) is shown.
3. Clicks the **B** button, the **I** button, and sets the Color swatch to `#ff00aa`.
4. Re-queries the element and asserts `getComputedStyle().color === 'rgb(255, 0, 170)'`, `fontStyle === 'italic'`, and `fontWeight` is bold/700.

Results:

| Element | Color | Italic | Bold | Toolbar |
|---|---|---|---|---|
| `.vr-entry-title` | ✅ | ✅ | ✅ | ✅ |
| `.vr-entry-body`  | ✅ | ✅ | ✅ | ✅ |
| `.sname` (control) | ✅ | ✅ | ✅ | ✅ |

Pre-fix (commit 1 only): `vr-entry-title` and `vr-entry-body` color/italic remained unchanged after panel edits while `sname` worked.

## Test plan

- [x] Browser contract test (above) passes on the branch.
- [x] No console errors.
- [x] Other zone renderers (cover, announcements, calendar, serving, staff) untouched.
- [ ] Manual: open a real project with multiple volunteer roles. For each role, click title → set color/bold; click body → set color/italic; click QR (if URL present) → adjust layout. Confirm changes persist after Save and reload.
- [ ] Manual: regression — confirm other zones still respond to designer edits as before.