### PR TITLE
chore(ai-workflow): bootstrap AGENTS.md + docs/ai scaffolding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# AGENTS.md
+
+Operating contract for AI agents working in this repo. Pair with `CLAUDE.md` (the full architectural reference) and `docs/ai/*` (planning + state memory).
+
+## First files to read
+
+1. `CLAUDE.md` — what the app is, key files, data flow, deployment modes, common gotchas.
+2. `docs/ai/project-state.md` — current focus, recent work, open risks.
+3. `docs/ai/architecture.md` — boundaries between server, frontend modules, and the two deployment modes.
+4. `docs/ai/repo-map.md` — directory layout and where to grep first.
+5. `docs/ai/testing-guide.md` — how to run the app, what to verify, what is manual-only.
+6. The most recent commits on `main` (`git log --oneline -20`).
+
+## Data-safety rules
+
+- Treat `data/projects.json`, `data/announcements.json`, `data/settings.json`, and `data/song_database.json` as user data. Never delete, never commit, never overwrite. They live in `./data/` (Docker bind mount) or `~/Library/Application Support/BulletinGenerator/` (desktop).
+- Only the `*.example.json` siblings under `data/` are checked in. `_initialize_local_file()` in `server.py` copies them on first run; never modify that contract.
+- Atomic writes only: all JSON writes go through `_write_json()` in `server.py`. Never write a JSON file directly.
+- Migrations are tracked in `data/migrations.json` via `run_migrations()`. Keep them idempotent and additive.
+
+## Testing rules
+
+- This repo has no automated test suite. Validation is:
+  1. `python3 -c 'import server'` and `node --check src/js/<file>.js` for syntax sanity.
+  2. Manual smoke via `python3 server.py` (or the launch.json preview server on port 8766) — load the app, exercise the changed surface.
+  3. Browser DevTools console must be free of new errors after the change.
+- Changes that touch the Template Designer, preview render, or PDF generation require a manual click-through. Build/launch verification alone is insufficient.
+
+## Git + manual-merge rules
+
+- Always work on a feature branch — never on `main`.
+- One focused branch per concern. Don't mix bug fixes with refactors or doc bootstrapping.
+- Commit messages use Conventional Commits (`fix(scope): …`, `feat(scope): …`, `chore: …`).
+- Open draft PRs; **merge is always manual**. Do not auto-merge.
+- Never use `--no-verify` or `git push --force` to `main`.
+
+## Memory-update rules
+
+- After any non-trivial change, update `docs/ai/project-state.md`.
+- After an architectural decision (deployment mode shift, new dependency, new data file, schema change), append to `docs/ai/decisions.md`.
+- Keep memory factual and concise. If you don't know a fact, mark it `Unknown` rather than inventing.

--- a/docs/ai/architecture.md
+++ b/docs/ai/architecture.md
@@ -1,0 +1,43 @@
+# Architecture
+
+See `CLAUDE.md` for the canonical, detailed reference. This file is the high-level summary for agents.
+
+## App summary
+
+Church bulletin generator. Imports a service plan from Planning Center Online, pulls events from Google Calendar / iCal, lets a user arrange order-of-worship and announcements, and exports a print-ready PDF (headless Chrome).
+
+## Two deployment modes
+
+- **`desktop`** (default in `.app` bundle): single-user, port 8765, `launcher.py` manages server lifecycle, OAuth creds bundled in `desktop_config.py`, data at `~/Library/Application Support/BulletinGenerator/`. Updates via GitHub zip download.
+- **`server`**: multi-user, port 8080, Docker-managed, data at `/app/data` bind-mounted to `./data`, OAuth creds from env vars. Updates via Watchtower sidecar. Adds 409 conflict detection (revision + editor attribution).
+
+Mode is decided by `APP_MODE` env var. JS-side check: `isServerMode()` in `api.js`. Python-side: `APP_MODE` / `IS_DESKTOP` in `server.py`.
+
+## Data flow
+
+```
+PCO + Google Cal + iCal  ──►  server.py (proxy/fetch)  ──►  src/js/* (state)
+                                                              │
+                                                              ▼
+                       collectCurrentProjectState() ──► POST /api/projects ──► data/projects.json
+                                                              │
+                                                              ▼
+                       renderPreview() ──► page-split ──► print-ready HTML ──► /api/pdf ──► headless Chrome
+```
+
+## Major boundaries
+
+- **server.py ↔ frontend**: REST JSON API on the same port; no separate API gateway. Route dispatch is manual `startswith` in `do_GET` / `do_POST`.
+- **frontend ↔ state**: `state.js` owns top-level globals (`items[]`, `annData[]`, `vrData[]`, `servingSchedule`, `calEvents`). Modules read/write directly — no Redux/store layer.
+- **Preview vs Template Designer**: `preview.js` renders the live preview canvas the user prints. `templates.js` reuses that same DOM but adds a selectable-element overlay (`inferCanvasElement()` + `TPL_SELECTABLE_SELECTOR`). New zones must be wired in both.
+- **Editor cards vs preview elements**: Each section type often has two unrelated DOM trees — the side-panel editor card (e.g. `.vr-card` in `volunteer-roles.js`) and the preview element (e.g. `.vr-entry-*` in `preview.js`). The Template Designer operates on the preview tree, not the editor card.
+
+## External dependencies
+
+- **Runtime**: Planning Center API, Google Calendar API, `api.qrserver.com` (QR images), headless Chrome (PDF), GitHub Releases API (update checks).
+- **Python**: stdlib only for HTTP; `rumps` for desktop menu bar.
+- **JS**: no framework, no bundler. DaisyUI / Tailwind classes appear in markup; styling rules live in `index.html` / `styles.css`.
+
+## Conflict + sync model (server mode)
+
+`_clientRevision` posted with each save → server compares to stored revision → 409 if stale, returning `{ serverRevision, serverUpdatedBy, serverUpdatedAt }`. Frontend tracks `_loadedRevision` in `projects.js` and shows a conflict banner with a "Reload latest" link that fetches fresh from the server.

--- a/docs/ai/current-plan.md
+++ b/docs/ai/current-plan.md
@@ -1,0 +1,34 @@
+# Current Plan
+
+_Last updated: 2026-05-19_
+
+## User request
+
+Stabilize the Volunteer Roles feature (PRs #251, #252, #253). Most-recent in-flight item: fix Template Designer so volunteer-role elements are selectable / formattable like every other zone.
+
+## Goal
+
+Every previewable section type — including Volunteer Roles — must be fully wired in the Template Designer canvas: clickable, selectable, labeled, and formattable via per-element overrides.
+
+## Non-goals
+
+- Re-architecting the Template Designer.
+- Unifying the editor-card DOM and the preview DOM.
+- Adding new volunteer-role features (drag reorder in canvas, etc.). File separately.
+
+## Constraints
+
+- No JS bundler — files must remain directly loadable via `<script>` tags.
+- No new dependencies.
+- Backwards-compatible with existing project JSON; no migration required for this fix.
+
+## Phases / issues
+
+1. **#253 (in flight, branch `fix/template-editor-volunteer-roles-not-selectable`)** — add `.vr-entry-title` / `.vr-entry-body` / `.vr-entry-url` to `inferCanvasElement()` selector + branches, add to `TPL_SELECTABLE_SELECTOR`, add `nearestVolunteerRoleTitle()` helper.
+2. **Follow-up (not filed)** — audit other zones for the same gap and add a contributor checklist to `CLAUDE.md` "Common Gotchas": "When adding a new previewable section, update both `inferCanvasElement()` and `TPL_SELECTABLE_SELECTOR`."
+
+## Validation plan
+
+- Automated browser smoke via preview server (script in this PR's verification).
+- Manual click-through of every zone in Template Designer (see `testing-guide.md`).
+- PDF export still produces the expected output.

--- a/docs/ai/decisions.md
+++ b/docs/ai/decisions.md
@@ -1,0 +1,29 @@
+# Decisions
+
+Append-only log of architecture / workflow decisions worth preserving across sessions. Most-recent first.
+
+---
+
+## 2026-05-19 — Adopt the AI workflow `AGENTS.md` + `docs/ai/*` contract
+
+**Context.** Agent runs were degrading because the orchestrator's "self-heal before doing anything else" step kept finding the seven required workflow files missing, and either skipped the check (bad) or bootstrapped placeholder content inline in unrelated PRs (also bad).
+
+**Alternatives.**
+- Keep everything in `CLAUDE.md`. Rejected — single file conflates architectural reference (durable) with planning state (volatile), and the orchestrator looks for `docs/ai/*` by name.
+- Skip the contract and let each agent re-derive context. Rejected — wastes tokens and produces inconsistent assumptions across runs.
+
+**Decision.** Adopt the standard layout:
+- `AGENTS.md` — operating contract.
+- `docs/ai/project-state.md` — current focus + recent work.
+- `docs/ai/repo-map.md` — grep index.
+- `docs/ai/architecture.md` — boundaries.
+- `docs/ai/testing-guide.md` — validation commands + manual-only checks.
+- `docs/ai/current-plan.md` — what's being worked on right now.
+- `docs/ai/decisions.md` — this file.
+
+`CLAUDE.md` stays as the canonical detailed architecture reference; the new files reference it instead of duplicating.
+
+**Consequences.**
+- Future agent sessions can skip the bootstrap step and dispatch specialists directly.
+- `project-state.md` becomes the source of truth for "what's in flight" — must be updated by `project-state-updater` after every completed unit of work, not just at release time.
+- Anyone editing `CLAUDE.md` should sanity-check that `architecture.md` / `repo-map.md` haven't drifted.

--- a/docs/ai/project-state.md
+++ b/docs/ai/project-state.md
@@ -1,0 +1,30 @@
+# Project State
+
+_Last updated: 2026-05-19_
+
+## Current focus
+
+Stabilizing the Volunteer Roles feature added in releases 1.12.9 / 1.12.10 (PRs #251, #252). Recent fixes:
+
+- #252 — Volunteer Roles cards now render after server data loads (deferred-render bug).
+- #251 — Volunteer Roles render in preview + added Document menu toggle.
+- (in flight) #253 — Volunteer Roles elements are selectable / formattable in the Template Designer canvas. Branch `fix/template-editor-volunteer-roles-not-selectable`.
+
+## Recently completed
+
+- 1.12.10 release tagged (commit `b0b5f32`).
+- Watchtower scope label typo + periodic polling enabled (`d09dbce`).
+
+## In progress
+
+- Draft PR #253 awaiting manual smoke + merge.
+- AI-workflow doc bootstrap (this PR) to remove "missing AGENTS.md / docs/ai" self-heal pressure on future agent runs.
+
+## Open risks
+
+- No automated tests — every change requires manual click-through; easy to miss regressions in adjacent zones (Announcements, Calendar, Staff, Serving) when touching Template Designer code.
+- Memory note re: "Do NOT create PRs unless explicitly asked" is overly broad and has caused agents to skip the workflow's terminal step. Should be scoped to "without an explicit instruction or workflow that requires it."
+
+## Next step
+
+Manual smoke #253, merge, then close out 1.12.x by tagging a release if any further volunteer-roles polish lands.

--- a/docs/ai/repo-map.md
+++ b/docs/ai/repo-map.md
@@ -1,0 +1,57 @@
+# Repo Map
+
+See `CLAUDE.md` "Key Files" table for the full annotated list. This file is a quick orientation index for grep targets.
+
+## Top-level
+
+- `server.py` — Python stdlib `http.server`, all API routes, OAuth, PDF gen, ~1,485 lines.
+- `launcher.py` — macOS desktop launcher + menu bar (rumps).
+- `index.html` — single-page shell, loads `src/js/*` directly via `<script>` tags. No bundler.
+- `bulletin-generator.spec` — PyInstaller spec for `.app` build.
+- `docker-compose.yml` — server-mode container + Watchtower sidecar.
+- `requirements.txt`, `desktop_config.py(.example)`, `.env(.example)`.
+
+## `src/js/` (no bundler — files served as-is, `Cache-Control: no-store`)
+
+| File | Owns |
+|---|---|
+| `app.js` | Entry point, tab switching, init |
+| `state.js` | Global state, page-size presets, localStorage keys, type formats |
+| `api.js` | `apiFetch`, server-settings cache, mode detection |
+| `projects.js` | Save/load/delete, 409 conflict detection, autosave |
+| `editor.js` | Cover/logo, church name, item list rendering, page breaks |
+| `preview.js` | Live preview + page-split algorithm + print-ready HTML |
+| `formatting.js` | Per-item / per-type formatting; `getEffectiveFmt(item)` |
+| `pco.js` | Planning Center OAuth + service plan import |
+| `songs.js` | Song DB, title normalization, ProPresenter matching |
+| `propresenter.js` | Minimal `.pro6library` protobuf + RTF extraction |
+| `calendar.js` | iCal + Google Calendar OAuth/fetch/filter |
+| `announcements.js` | Announcement cards, formatting, page-break toggles |
+| `volunteer-roles.js` | Volunteer Roles cards UI (editor side panel) |
+| `staff.js` | Staff page rendering, role display, email linking |
+| `text-renderer.js` | Markdown → HTML, lyric/copyright splitting |
+| `update.js` | GitHub version check, Watchtower / desktop update UI |
+| `templates.js` | **Template Gallery + Template Designer canvas**. `inferCanvasElement()` maps DOM clicks → `{ binding, elementKey }`. `TPL_SELECTABLE_SELECTOR` is the click-delegation selector. Adding a new previewable section requires updating both. |
+| `utils.js` | Timestamps, status notifications, DOM helpers |
+
+## `data/`
+
+Runtime JSON (NOT committed): `projects.json`, `settings.json`, `announcements.json`, `song_database.json`, `migrations.json`. Their `.example.json` siblings ARE committed.
+
+## `docs/`
+
+- `docs/ARCHITECTURE.md` — deployment-mode notes + GitHub label strategy.
+- `docs/ai/*` — agent memory (this folder).
+- `docs/testing/` — manual smoke checklists (when present).
+
+## Common search terms
+
+- `binding:` — selectable-element registry entries in `templates.js`.
+- `ZONE_RENDERERS` / `DEFAULT_PREVIEW_ZONE_ORDER` — preview zone registry in `preview.js`.
+- `_write_json` — atomic JSON write helper in `server.py`.
+- `_clientRevision` — server-side conflict detection.
+- `isServerMode()` — JS mode check; `APP_MODE` / `IS_DESKTOP` in Python.
+
+## Generated / ignored
+
+`dist/`, `build/`, `__pycache__/`, `data/*.json` (not `.example.json`), `.env`, `desktop_config.py`.

--- a/docs/ai/testing-guide.md
+++ b/docs/ai/testing-guide.md
@@ -1,0 +1,64 @@
+# Testing Guide
+
+This repo has no automated test suite. Validation is a layered checklist agents should run before claiming work is done.
+
+## Install / setup assumptions
+
+- Python 3.11+, with `requirements.txt` installed in a venv.
+- `cp .env.example .env` and fill PCO + Google OAuth creds (server mode), or `cp desktop_config.py.example desktop_config.py` (desktop bundle).
+- Node available for syntax checks: `node --check src/js/<file>.js`.
+
+## Commands
+
+### Syntax / static checks
+
+```bash
+python3 -c "import server"         # server.py imports cleanly
+node --check src/js/templates.js   # repeat per file changed
+```
+
+### Run the app locally
+
+- Quick check via the workflow's preview server: it's configured in `.claude/launch.json` (`bulletin-generator`, port `8766`).
+- Manual:
+
+```bash
+python3 server.py            # port 8080 by default
+python3 server.py 8766       # alternate port
+```
+
+### Docker (server mode)
+
+```bash
+docker compose up --build
+```
+
+### Desktop build
+
+```bash
+pyinstaller bulletin-generator.spec
+# Output: dist/Bulletin Generator.app
+```
+
+## Manual-only checks
+
+These cannot be automated and must be smoke-tested by a human before merge:
+
+- **Template Designer click-through**: open Templates → Design on any template. Click every selectable element type (cover, section heading, song title, song lyrics, song copyright, label, liturgy, announcement title/body/QR, calendar day/title/time/location, serving week/service-time/team/role/name, volunteer-role title/body/URL, staff name/role/email). Each click should outline the element with 2px accent + 4 corner handles, populate the per-element formatting panel, and the aria-label should describe the element.
+- **PDF export**: round-trip a project to PDF and visually verify pagination, page breaks, footers, cover, and any QR codes.
+- **Project save/load + conflict**: in server mode, edit the same project in two browsers, save in one, save in the other → confirm 409 banner appears with diff and "Reload latest" works.
+- **PCO import + calendar fetch**: token-refresh paths only fire on real network errors; spot-check on real creds before shipping changes to `pco.js` or `calendar.js`.
+- **Console must be clean**: open DevTools, exercise the changed surface, confirm no new errors / warnings.
+
+## Health probes
+
+The app has no dedicated `/health` endpoint. Acceptable substitute: `GET /api/bootstrap` returns 200 with a JSON body once the server is ready.
+
+## Pre-handoff verification
+
+Before opening a PR or claiming done:
+
+1. Syntax checks above (every file changed).
+2. Start the app (`python3 server.py` or the preview server) and load `/`.
+3. Console must be clean after the changed flow runs.
+4. If the change touches Template Designer wiring, exercise at least one element of every zone — not just the one you changed.


### PR DESCRIPTION
## Summary
- Adds the seven files the workflow-orchestrator skill expects at the repo root so future agent sessions can run their "self-heal before dispatching specialists" check cleanly.
- `CLAUDE.md` remains the canonical, detailed architecture reference. The new files cross-link to it instead of duplicating.

## Files added
- `AGENTS.md` — operating contract (data-safety, testing, git, memory rules).
- `docs/ai/project-state.md` — current focus + in-flight work (Volunteer Roles stabilization, PR #253).
- `docs/ai/repo-map.md` — grep index pointing at the CLAUDE.md key-files table.
- `docs/ai/architecture.md` — high-level summary.
- `docs/ai/testing-guide.md` — syntax checks + manual-only checklist (no automated test suite in this repo).
- `docs/ai/current-plan.md` — Volunteer Roles stabilization plan.
- `docs/ai/decisions.md` — append-only decision log, seeded with the adoption rationale.

## Test plan
- [x] Files render correctly as Markdown.
- [x] No code changes; no functional risk.
- [ ] Spot-check: next AI workflow run should now pass the file-presence check without bootstrapping inline.