### PR TITLE
perf(projects): lightweight stale-check poll endpoint

### DIFF
--- a/docs/ai/contracts/lightweight-projects-poll.json
+++ b/docs/ai/contracts/lightweight-projects-poll.json
@@ -1,0 +1,33 @@
+{
+  "issue": "lightweight-projects-poll",
+  "title": "Stale-check poll must not download full project state (base64 images)",
+  "generated": "2026-05-28",
+  "context": "The 30s stale-check poll in src/js/projects.js calls GET /api/projects, which returns the entire projects.json (~8.4 MB, including base64 cover/logo images). With multiple open tabs this transferred ~279 GB over a few weeks. The poll only needs id/revision/updatedAt/updatedBy per project.",
+  "criteria": [
+    {
+      "criterion_id": "lightweight-poll-c1",
+      "text": "A server helper _project_revision_summary(projects) returns one entry per project containing only id, revision, updatedAt, updatedBy — and excludes the heavy `state` field (base64 images). Serialized payload is at least 10x smaller than the full project list.",
+      "mode": "unit",
+      "test_file": "tests/test_server_utils.py",
+      "test_id": "TestProjectRevisionSummary::test_summary_excludes_heavy_state / test_summary_preserves_metadata / test_summary_payload_is_tiny",
+      "status": "pending"
+    },
+    {
+      "criterion_id": "lightweight-poll-c2",
+      "text": "GET /api/projects/revisions is registered as an exact-match route mapping to _handle_get_project_revisions, distinct from /api/projects.",
+      "mode": "unit",
+      "test_file": "tests/test_server_utils.py",
+      "test_id": "TestProjectRevisionSummary::test_revisions_route_registered",
+      "status": "pending"
+    },
+    {
+      "criterion_id": "lightweight-poll-c3",
+      "text": "The frontend stale-check poll (src/js/projects.js startStaleCheck) calls /api/projects/revisions instead of /api/projects; the explicit 'Reload latest' click handler still fetches full /api/projects.",
+      "mode": "manual",
+      "status": "UNVERIFIED",
+      "reason": "Frontend JS is loaded via plain <script> tags with no module seam for the polling timer; behavior is verified by manual smoke (observe network tab) rather than an automated test."
+    }
+  ],
+  "stack": "python",
+  "not_tested": ["lightweight-poll-c3"]
+}

--- a/docs/ai/decisions.md
+++ b/docs/ai/decisions.md
@@ -4,6 +4,23 @@ Append-only log of architecture / workflow decisions worth preserving across ses
 
 ---
 
+## 2026-05-28 — Separate `/api/projects/revisions` endpoint for the stale-check poll
+
+**Context.** The 30s stale-check poll (`startStaleCheck` in `src/js/projects.js`) called `GET /api/projects`, which returns the entire `projects.json` — ~8.6 MB because project `state` embeds base64 cover/logo images. With multiple browser tabs open this transferred ~279 GB over a few weeks and inflated server RSS (repeated multi-MB JSON parse/serialize). The poll only reads `revision`/`updatedAt`/`updatedBy`.
+
+**Alternatives.**
+- Add a `?fields=meta` query param to `/api/projects`. Rejected — the route is exact-match (`path == '/api/projects'`); supporting a variant would mean parsing query strings in the handler, and a distinct path is clearer and cache-friendlier.
+- Strip `state` from the existing `/api/projects` response. Rejected — startup (`loadAllFromServer`) and the explicit "Reload latest" handlers genuinely need full `state`.
+- Gzip the response. Rejected — reduces bytes but still re-parses/re-serializes 8.6 MB server-side every cycle; doesn't fix RSS.
+
+**Decision.** Added `_project_revision_summary(projects)` (metadata-only: id/revision/updatedAt/updatedBy) and an exact-match `GET /api/projects/revisions` route → `_handle_get_project_revisions`. The poll now hits the new endpoint (~799 bytes vs 8.6 MB, ~10,800× smaller). The two explicit user-triggered "Reload latest" handlers and startup load still use full `/api/projects`.
+
+**Consequences.**
+- Stale-check bandwidth is now negligible; the Cloudflare-vs-Tailscale choice can be made on features/security rather than data volume.
+- Any future field the poll needs must be added to `_project_revision_summary`, not assumed present.
+
+---
+
 ## 2026-05-19 — Adopt the AI workflow `AGENTS.md` + `docs/ai/*` contract
 
 **Context.** Agent runs were degrading because the orchestrator's "self-heal before doing anything else" step kept finding the seven required workflow files missing, and either skipped the check (bad) or bootstrapped placeholder content inline in unrelated PRs (also bad).

--- a/docs/ai/project-state.md
+++ b/docs/ai/project-state.md
@@ -1,10 +1,12 @@
 # Project State
 
-_Last updated: 2026-05-19_
+_Last updated: 2026-05-28_
 
 ## Current focus
 
-Stabilizing the Volunteer Roles feature added in releases 1.12.9 / 1.12.10 (PRs #251, #252). Recent fixes:
+Performance/bandwidth fix: the 30s stale-check poll was downloading the full ~8.6 MB `projects.json` every cycle (root cause of ~279 GB transferred over a few weeks). Fixed on branch `fix/lightweight-projects-poll` — see "Recent coding-agent runs" below and the 2026-05-28 entry in `decisions.md`. Pending: manual smoke + draft PR.
+
+Prior focus — stabilizing the Volunteer Roles feature added in releases 1.12.9 / 1.12.10 (PRs #251, #252). Recent fixes:
 
 - #252 — Volunteer Roles cards now render after server data loads (deferred-render bug).
 - #251 — Volunteer Roles render in preview + added Document menu toggle.
@@ -17,14 +19,27 @@ Stabilizing the Volunteer Roles feature added in releases 1.12.9 / 1.12.10 (PRs 
 
 ## In progress
 
+- `fix/lightweight-projects-poll` — lightweight stale-check endpoint. Verified (pytest 95, vitest 83, vite build, server smoke). Awaiting draft PR + manual smoke (observe Network tab: 30s poll should hit `/api/projects/revisions`, small response).
 - Draft PR #253 awaiting manual smoke + merge.
-- AI-workflow doc bootstrap (this PR) to remove "missing AGENTS.md / docs/ai" self-heal pressure on future agent runs.
 
 ## Open risks
 
-- No automated tests — every change requires manual click-through; easy to miss regressions in adjacent zones (Announcements, Calendar, Staff, Serving) when touching Template Designer code.
+- Automated coverage is partial: pytest covers server.py utilities/handlers and vitest covers `src/js/modules/*` pure logic, but UI behavior (rendering, Template Designer, poll timer) is not automated and needs manual click-through. Easy to miss regressions in adjacent zones (Announcements, Calendar, Staff, Serving) when touching shared code.
 - Memory note re: "Do NOT create PRs unless explicitly asked" is overly broad and has caused agents to skip the workflow's terminal step. Should be scoped to "without an explicit instruction or workflow that requires it."
 
 ## Next step
 
-Manual smoke #253, merge, then close out 1.12.x by tagging a release if any further volunteer-roles polish lands.
+Manual smoke the poll fix (confirm `/api/projects/revisions` is used and small), open its draft PR. Then manual smoke #253, merge, and close out 1.12.x by tagging a release if any further volunteer-roles polish lands.
+
+## Recent coding-agent runs
+
+### 2026-05-28 — lightweight-projects-poll
+- Files modified:
+  - `server.py` — added `_project_revision_summary(projects)` helper and `_handle_get_project_revisions` handler + exact-match GET route `/api/projects/revisions` (metadata-only: id/revision/updatedAt/updatedBy, omits heavy base64-image `state`).
+  - `src/js/projects.js` — `startStaleCheck()` 30s poll now calls `/api/projects/revisions` instead of `/api/projects`. The two explicit "Reload latest" click handlers still fetch full `/api/projects` (they need full state).
+  - `tests/test_server_utils.py` — added `TestProjectRevisionSummary` (5 contract tests).
+  - `docs/ai/contracts/lightweight-projects-poll.json` — acceptance contract.
+- Why: the 30s stale-check poll downloaded the entire projects.json (~8.4 MB, base64 cover/logo images) every cycle. Across multiple open tabs this transferred ~279 GB over a few weeks and inflated RSS. The poll only needs revision metadata.
+- Checks run: `pytest tests/test_server_utils.py::TestProjectRevisionSummary` → 5 passed (red→green confirmed). Full verification pending verification-gate.
+- Deviations from spec: none.
+- Concerns: frontend poll behavior (contract criterion `lightweight-poll-c3`) is manual-smoke-only — no module seam for the polling timer. Confirm via browser Network tab that the 30s poll hits `/api/projects/revisions` with a small response.

--- a/server.py
+++ b/server.py
@@ -506,6 +506,24 @@ def _write_json(path, data):
     tmp.replace(path)
 
 
+def _project_revision_summary(projects):
+    """Metadata-only view of projects for the stale-check poll.
+
+    Returns just the fields the 30s poll needs (id/revision/updatedAt/updatedBy),
+    omitting `state` — which embeds base64 cover/logo images and makes the full
+    project list multi-megabyte.
+    """
+    return [
+        {
+            "id":        p.get("id"),
+            "revision":  p.get("revision"),
+            "updatedAt": p.get("updatedAt"),
+            "updatedBy": p.get("updatedBy"),
+        }
+        for p in projects
+    ]
+
+
 # ─── iCal parsing ─────────────────────────────────────────────────────────────
 
 def unfold_ical(text):
@@ -1101,6 +1119,7 @@ class Handler(http.server.SimpleHTTPRequestHandler):
         ('/index.html',               '_handle_index'),
         ('/worship-booklet.html',     '_handle_index'),
         ('/favicon.ico',              '_handle_favicon'),
+        ('/api/projects/revisions',   '_handle_get_project_revisions'),
         ('/api/projects',             '_handle_get_projects'),
         ('/api/announcements',        '_handle_get_announcements'),
         ('/api/volunteer-roles',      '_handle_get_volunteer_roles'),
@@ -1196,6 +1215,10 @@ class Handler(http.server.SimpleHTTPRequestHandler):
 
     def _handle_get_projects(self):
         self._send_json({"projects": _read_json(PROJECTS_FILE, [])})
+
+    def _handle_get_project_revisions(self):
+        """Lightweight poll target: project metadata without heavy `state`."""
+        self._send_json({"projects": _project_revision_summary(_read_json(PROJECTS_FILE, []))})
 
     def _handle_get_announcements(self):
         self._send_json(_read_json(ANNOUNCEMENTS_FILE, []))

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -472,7 +472,9 @@ function startStaleCheck() {
     if (!activeProjectId) return;
     try {
       const staleBanner = document.getElementById('stale-banner');
-      const data = await apiFetch('/api/projects');
+      // Poll lightweight metadata only — the full /api/projects payload embeds
+      // base64 images and is multi-megabyte. We only need revision/updatedAt here.
+      const data = await apiFetch('/api/projects/revisions');
       const serverProject = (data.projects || []).find(p => p.id === activeProjectId);
       if (!serverProject) {
         staleBanner.style.display = 'none';

--- a/tests/test_server_utils.py
+++ b/tests/test_server_utils.py
@@ -350,3 +350,75 @@ class TestParseListEnv:
         with patch.dict(os.environ, {"TEST_LIST_ENV": "  a , b , c  "}):
             result = server._parse_list_env("TEST_LIST_ENV")
             assert result == ["a", "b", "c"]
+
+
+# ── Lightweight stale-check poll (contract: lightweight-projects-poll) ──────────
+
+class TestProjectRevisionSummary:
+    """Contract tests for the lightweight stale-check polling endpoint.
+
+    The 30s stale-check poll must NOT download full project state (which
+    embeds base64 cover/logo images, ~8.4 MB total). _project_revision_summary
+    returns metadata only, and GET /api/projects/revisions serves it.
+    """
+
+    def _sample_projects(self):
+        big_image = "data:image/png;base64," + ("A" * 50000)
+        return [
+            {
+                "id": "p1",
+                "revision": 5,
+                "updatedAt": "2026-05-28T10:00:00Z",
+                "updatedBy": "Alice",
+                "createdAt": "2026-05-01T00:00:00Z",
+                "createdBy": "Alice",
+                "name": "Sunday Service",
+                "state": {"coverImage": big_image, "items": [1, 2, 3]},
+            },
+            {
+                "id": "p2",
+                "revision": 2,
+                "updatedAt": "2026-05-27T09:00:00Z",
+                "updatedBy": "Bob",
+                "state": {"logoImage": big_image},
+            },
+        ]
+
+    def test_summary_excludes_heavy_state(self):
+        """lightweight-poll-c1: summary must not include `state` or images."""
+        summary = server._project_revision_summary(self._sample_projects())
+        for entry in summary:
+            assert "state" not in entry
+            assert set(entry.keys()) == {"id", "revision", "updatedAt", "updatedBy"}
+
+    def test_summary_preserves_metadata(self):
+        """lightweight-poll-c1: summary keeps id/revision/updatedAt/updatedBy."""
+        summary = server._project_revision_summary(self._sample_projects())
+        assert summary[0] == {
+            "id": "p1", "revision": 5,
+            "updatedAt": "2026-05-28T10:00:00Z", "updatedBy": "Alice",
+        }
+        assert summary[1] == {
+            "id": "p2", "revision": 2,
+            "updatedAt": "2026-05-27T09:00:00Z", "updatedBy": "Bob",
+        }
+
+    def test_summary_fills_missing_metadata_with_none(self):
+        """lightweight-poll-c1: all four keys present even when absent in source."""
+        summary = server._project_revision_summary([{"id": "p3"}])
+        assert summary[0] == {
+            "id": "p3", "revision": None, "updatedAt": None, "updatedBy": None,
+        }
+
+    def test_summary_payload_is_tiny(self):
+        """lightweight-poll-c1: serialized summary >10x smaller than full state."""
+        projects = self._sample_projects()
+        full = json.dumps({"projects": projects})
+        summary = json.dumps({"projects": server._project_revision_summary(projects)})
+        assert len(summary) < len(full) / 10
+
+    def test_revisions_route_registered(self):
+        """lightweight-poll-c2: GET /api/projects/revisions route is wired."""
+        routes = dict(server.Handler._GET_ROUTES)
+        assert routes.get("/api/projects/revisions") == "_handle_get_project_revisions"
+        assert hasattr(server.Handler, "_handle_get_project_revisions")


### PR DESCRIPTION
## Summary
- The 30s stale-check poll (`startStaleCheck` in `src/js/projects.js`) called `GET /api/projects`, which returns the entire `projects.json` (~8.6 MB — project `state` embeds base64 cover/logo images). Across multiple open browser tabs this transferred **~279 GB over a few weeks** and inflated server RSS from repeated multi-MB JSON parse/serialize.
- Adds `_project_revision_summary()` + an exact-match `GET /api/projects/revisions` route returning only `id`/`revision`/`updatedAt`/`updatedBy`.
- Points the poll at the new endpoint: **~799 bytes vs 8.6 MB per cycle (~10,800× smaller)**, measured against real `data/projects.json`.
- The two explicit "Reload latest" handlers and startup `loadAllFromServer` still use full `/api/projects` (they need full `state`).

## Verification
- `pytest` CI set → **95 passed** (90 baseline + 5 new contract tests in `TestProjectRevisionSummary`).
- `vitest` → 83 passed. `vite build` → green.
- Server smoke (booted `server.py`, real data): `/api/projects/revisions` → HTTP 200, **799 bytes, 0 base64 images**; `/api/projects` → HTTP 200, **8,639,237 bytes, 1 base64 image** (control).
- Acceptance contract: `docs/ai/contracts/lightweight-projects-poll.json`.

## Test plan
- [ ] Server mode, two browser tabs on the same project: edit + save in tab A; confirm tab B shows the "updated by … Reload latest" banner within ~30s.
- [ ] DevTools Network tab: confirm the recurring poll hits `/api/projects/revisions` with a small (sub-KB) response, **not** `/api/projects`.
- [ ] Click "Reload latest" → confirm it still fetches full state and the diff/confirm prompt appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Reconciliation with collab-v1 (#250)

This is an **interim** fix. The in-flight `collab-v1` initiative (PR #250, issue #220) already adds an **auth-aware** lightweight poll endpoint — `GET /api/projects/{id}/revision` — backed by Postgres + per-user sessions, and a `src/js/modules/stale-poll-core.js` poll refactor.

When collab-v1 lands, the stale-check poll should converge on that per-project, authenticated endpoint, and the simpler `/api/projects/revisions` route added here becomes redundant and should be removed. This PR exists to stop the ~279 GB/few-weeks bandwidth bleed **now**, since collab-v1 is a large WIP that is not merging imminently.
