### PR TITLE
test(e2e): Playwright foundation + fix presence project_id TEXT 500

### DIFF
--- a/.env.e2e.example
+++ b/.env.e2e.example
@@ -12,3 +12,7 @@ E2E_LIVE_PASSWORD=...
 
 # Optional: where the app is served during tests
 E2E_BASE_URL=http://127.0.0.1:8080
+
+# Python 3.10+ interpreter for server.py (default: python3). Set if your
+# system python3 is older, e.g. .venv/bin/python
+E2E_PYTHON=python3

--- a/.env.e2e.example
+++ b/.env.e2e.example
@@ -1,0 +1,14 @@
+# The single hosted Supabase project (the same one worship@ lives in).
+# Both lanes use it; the core lane isolates via ephemeral e2e- identities.
+SUPABASE_URL=https://YOUR_REF.supabase.co
+SUPABASE_ANON_KEY=eyJ...anon...
+SUPABASE_JWT_SECRET=your-test-jwt-secret
+SUPABASE_SERVICE_ROLE_KEY=eyJ...service_role...   # setup/teardown only
+DATABASE_URL=postgresql://postgres:pw@db.YOUR_REF.supabase.co:5432/postgres
+
+# Live lane only — the already-connected workspace account
+E2E_LIVE_EMAIL=worship@visaliacrc.com
+E2E_LIVE_PASSWORD=...
+
+# Optional: where the app is served during tests
+E2E_BASE_URL=http://127.0.0.1:8080

--- a/.github/workflows/e2e-core.yml
+++ b/.github/workflows/e2e-core.yml
@@ -1,0 +1,30 @@
+name: E2E Core (PR gate)
+on:
+  push:
+    branches: [main]
+  pull_request:
+jobs:
+  e2e-core:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20', cache: 'npm' }
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.12' }
+      - run: pip install -r requirements.txt
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - name: Run core lane
+        env:
+          CI: 'true'
+          SUPABASE_URL: ${{ secrets.E2E_SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.E2E_SUPABASE_ANON_KEY }}
+          SUPABASE_JWT_SECRET: ${{ secrets.E2E_SUPABASE_JWT_SECRET }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.E2E_SUPABASE_SERVICE_ROLE_KEY }}
+          DATABASE_URL: ${{ secrets.E2E_DATABASE_URL }}
+        run: npx playwright test --project=core
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with: { name: playwright-report, path: playwright-report/, retention-days: 7 }

--- a/.github/workflows/e2e-core.yml
+++ b/.github/workflows/e2e-core.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with: { node-version: '20', cache: 'npm' }
+        with: { node-version: '22', cache: 'npm' }
       - uses: actions/setup-python@v5
         with: { python-version: '3.12' }
       - run: pip install -r requirements.txt

--- a/.github/workflows/e2e-live.yml
+++ b/.github/workflows/e2e-live.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with: { node-version: '20', cache: 'npm' }
+        with: { node-version: '22', cache: 'npm' }
       - uses: actions/setup-python@v5
         with: { python-version: '3.12' }
       - run: pip install -r requirements.txt

--- a/.github/workflows/e2e-live.yml
+++ b/.github/workflows/e2e-live.yml
@@ -1,0 +1,32 @@
+name: E2E Live (real integrations)
+on:
+  schedule:
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+jobs:
+  e2e-live:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20', cache: 'npm' }
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.12' }
+      - run: pip install -r requirements.txt
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - name: Run live lane
+        env:
+          CI: 'true'
+          SUPABASE_URL: ${{ secrets.E2E_SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.E2E_SUPABASE_ANON_KEY }}
+          SUPABASE_JWT_SECRET: ${{ secrets.E2E_SUPABASE_JWT_SECRET }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.E2E_SUPABASE_SERVICE_ROLE_KEY }}
+          DATABASE_URL: ${{ secrets.E2E_DATABASE_URL }}
+          E2E_LIVE_EMAIL: ${{ secrets.E2E_LIVE_EMAIL }}
+          E2E_LIVE_PASSWORD: ${{ secrets.E2E_LIVE_PASSWORD }}
+        run: npx playwright test --project=live
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with: { name: playwright-report-live, path: playwright-report/, retention-days: 14 }

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .env
 .env.*
 !.env.example
+!.env.e2e.example
 desktop_config.py
 
 # PyInstaller build output

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,9 @@ tmp/
 .agent-stack/
 .agents/
 skills-lock.json
+
+# Playwright E2E
+/test-results/
+/playwright-report/
+/tests/e2e/.auth/
+/tests/e2e/recordings/*.local.har

--- a/docs/ai/decisions.md
+++ b/docs/ai/decisions.md
@@ -4,6 +4,17 @@ Append-only log of architecture / workflow decisions worth preserving across ses
 
 ---
 
+## 2026-06-05 — Presence project_id is TEXT, not uuid (fix forward migration, not edit-in-place)
+
+**Context.** `workspace_presences.project_id` was declared `uuid` in `20260603000003_workspace_presences.sql`, but project ids are application-generated TEXT (`proj_<timestamp>_<rand>`) and `public.projects.id` is `text`. Every presence read/heartbeat 500'd with `InvalidTextRepresentation`; the frontend's best-effort error swallowing hid it.
+
+**Decision.** Fix via a **new additive migration** (`20260605000002_presence_project_id_text.sql`) that idempotently `ALTER COLUMN project_id TYPE text`, rather than editing the original applied migration. Consistent with AGENTS.md's "migrations are idempotent and additive" rule — never rewrite an applied migration. A fresh DB applies both in order (create uuid → alter to text); existing DBs convert losslessly.
+
+**Consequences.**
+- The fix lives only in `supabase/migrations/*` (the Supabase-platform migration track), not the Python `migrations/runner.py` track — the presence table belongs to the former.
+- No `server.py` query change: the handlers bind `project_id` as a plain string param (no `::uuid` cast), so the column-type change is the whole fix. Corrected the handlers' `<uuid>` docstrings to `<project-id>` so the wrong assumption isn't reintroduced.
+- **Rule for any future table keyed by a project id: use `text`, never `uuid`.** Project ids are not uuids.
+
 ## 2026-06-04 — Abandoned Share-to-Workspace; confirmed visibility model A (workspace-visible by default + hand-off)
 
 **Context.** The "private-by-default + explicit share-to-workspace" model planned in issues 020/023 was only partly realized: `PostgresStorageBackend.save_project` hard-codes `visibility = 'workspace'` on INSERT (storage.py), so new projects were always workspace-visible despite the issue-020 migration setting the column *default* to `'private'`. No Share UI was ever built — the `POST /api/projects/{id}/share` endpoint had no frontend caller.

--- a/docs/ai/project-state.md
+++ b/docs/ai/project-state.md
@@ -1,6 +1,6 @@
 # Project State
 
-_Last updated: 2026-06-04 (v0.0.4 packaged app boots & verified working on macOS 26.5/arm64 — 5 latent build defects fixed)_
+_Last updated: 2026-06-05 (presence endpoint 500 fixed — workspace_presences.project_id uuid→text)_
 
 ## Current focus
 
@@ -8,7 +8,11 @@ Branch: `feat/supabase-multitenant-electron`. Milestone: Supabase + Multi-tenant
 
 Issues 001–023 are implemented and automated-verified on this branch. Issue 023 (remove conflict detection, add presence heartbeat + read-only mode for non-owners) is DONE.
 
+Side branch `test/e2e-playwright-foundation` holds the Playwright E2E suite; its Projects spec surfaced the presence 500 (see below).
+
 ## Recently completed
+
+- **Presence endpoint 500 fixed (branch `test/e2e-playwright-foundation`).** `workspace_presences.project_id` was created as `uuid` (migration `20260603000003_workspace_presences.sql`) but `public.projects.id` is **TEXT** (`proj_<ts>_<rand>`). Binding a TEXT project id against the uuid column raised `psycopg.errors.InvalidTextRepresentation`, 500-ing every `GET /api/presence` and `POST /api/presence/heartbeat` for real projects — silently, because the frontend swallows presence errors (best-effort). Presence was fully broken for all projects. **Fix:** new additive migration `supabase/migrations/20260605000002_presence_project_id_text.sql` idempotently alters the column to `text` (uuid→text is a lossless widening cast; PK + index rebuilt automatically). Applied live to the Supabase project. Also corrected two now-misleading `<uuid>` docstrings in `server.py` presence handlers (the false "uuid" assumption is what caused the bug). **No Python query change needed** — handlers bind `project_id` as a plain string with no `::uuid` cast. **Verified:** live column `data_type=text`; faithful DB round-trip through the exact heartbeat-upsert + GET query shapes with a TEXT `proj_...` id returned the row with no error (old uuid column would have raised); `ai-workflow checks --level issue` and `--level pr` both PASS (vite build + pytest + vitest). Surfaced by `tests/e2e/features/projects.spec.ts`. Full HTTP-level E2E confirmation (live auth session) belongs in manual smoke.
 
 - **Abandoned Share-to-Workspace; confirmed visibility model A (workspace-visible by default + hand-off).** Removed dead code: `_handle_share_project` + dispatch (server.py), `share_project_to_workspace` (all 3 storage backends), `tests/test_share_project.py`. Issue 020's private-by-default is obsolete (the `'private'` column default is vestigial — `save_project` forces `'workspace'`; owner-only-write RLS retained). Docs reconciled (decisions.md, architecture.md, current-plan.md, issue #272). GitHub #211 closed not-planned. See `decisions.md` 2026-06-04. NOTE: `python -c "import server"` OK; project/auth tests unchanged (108 pass; 1 pre-existing test-ordering pollution failure in `test_project_visibility.py::TestGetProjectsList` that also fails on committed code — unrelated, worth a separate isolation fix).
 - **Packaged Electron app made to actually boot (v0.0.4, verified working).** The released DMGs (v0.0.1) had never been boot-tested; five latent build defects surfaced in sequence on macOS 26.5/arm64. All fixed on `feat/supabase-multitenant-electron`, shipped via tags `electron-supabase-beta-v0.0.2/3/4` (draft prereleases):

--- a/docs/superpowers/plans/2026-06-05-e2e-playwright-foundation.md
+++ b/docs/superpowers/plans/2026-06-05-e2e-playwright-foundation.md
@@ -606,7 +606,9 @@ git commit -m "test(e2e): add two-lane Playwright config with webServer + setup/
 
 ### Task 8: Auth setup & teardown projects
 
-> Setup signs in via supabase-js in a real browser context so we capture whatever localStorage key supabase-js uses, then save `storageState`. Core uses the ephemeral identity (ids written to disk for teardown); live uses `worship@`.
+> Setup signs in via supabase-js in a real browser context so we capture whatever localStorage key supabase-js uses, then save `storageState`. Core uses the ephemeral identity (ids written to disk for teardown).
+>
+> **DECISION (2026-06-05): live lane uses a dedicated `e2e-live` member, NOT `worship@` directly.** `worship@` has no password (Google/magic-link). Instead, live-setup ensures a persistent `e2e-live@e2e.bulletin.test` user (password in `.env.e2e` `E2E_LIVE_PASSWORD`) exists and is a member of `worship@`'s workspace — so it inherits the per-workspace connected PCO/Google tokens. Read-only. This requires a new helper `ensureLiveWorkspaceMember()` in `supabase-admin.ts` that: (1) resolves `worship@`'s `workspace_id` via `profiles`→`workspace_members`, (2) creates the `e2e-live` user if absent (idempotent, via `service_role` admin API with `email_confirm:true`), (3) upserts its `workspace_members` row with role `viewer`. The live-setup spec then signs in as `E2E_LIVE_EMAIL`/`E2E_LIVE_PASSWORD`. The `auth.setup.ts` `@live-setup` block below must be updated to call this helper instead of signing in as `worship@`.
 
 **Files:**
 - Create: `tests/e2e/helpers/auth.setup.ts`

--- a/docs/superpowers/plans/2026-06-05-e2e-playwright-foundation.md
+++ b/docs/superpowers/plans/2026-06-05-e2e-playwright-foundation.md
@@ -1,0 +1,957 @@
+# E2E Playwright Suite — Phase 1 (Foundation) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up a trustworthy two-lane Playwright harness against the real `server.py` + real hosted Supabase, ending in one green end-to-end smoke test in both the deterministic (core) and live lanes, wired into CI.
+
+**Architecture:** Playwright drives the real frontend served by a real `server.py` running in server mode (`APP_MODE=server`, port 8080). Auth is Supabase Bearer-JWT. A "setup" Playwright project provisions an isolated ephemeral Supabase user+workspace (via `service_role`) for the core lane and signs in as `worship@visaliacrc.com` for the live lane, each saving a `storageState`. A matching "teardown" project deletes the ephemeral identity. Determinism comes from Playwright's `page.clock`. This phase delivers the harness + smoke only; exhaustive coverage is later phases.
+
+**Tech Stack:** `@playwright/test` (TypeScript), `@supabase/supabase-js` (already a dependency), Python 3 `server.py`, hosted Supabase Postgres, GitHub Actions.
+
+**Reference spec:** `docs/superpowers/specs/2026-06-05-e2e-playwright-suite-design.md`
+
+---
+
+## Key facts (verified against source — do not re-derive)
+
+- Boot: `python3 server.py` runs server mode by default. `APP_MODE` (server.py:256) defaults to `"server"`; server binds `0.0.0.0:8080` via `run_server(port=8080)` (server.py:3359).
+- Server-mode required env: `DATABASE_URL`, `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_JWT_SECRET` (validated server.py:268–286).
+- Auth: client sends `Authorization: Bearer <access_token>`; `apiFetch` attaches it from the supabase-js session (api.js:3–26, line 7). Server verifies via `auth.authenticate_authorization_header` (auth.py:287).
+- `/api/me` server-mode 200 body: `{"mode":"server","user_id","email","workspace_id","role"}`; 401 when unauthenticated.
+- Supabase config injected at `GET /src/js/supabase-config.js` as `globalThis.BULLETIN_SUPABASE_CONFIG = {url, anonKey}` (server.py:1376).
+- Workspace provisioning is **domain-allow-list gated** (`provision_first_login`, auth.py:203–284). Arbitrary new users get **403, no workspace**. Therefore ephemeral test identities MUST be created directly via `service_role` (create user + workspace + `workspace_members` row), not via normal login.
+- Tables (migrations `supabase/migrations/20260602000001_*` and `_002_*`): `profiles(id,email,display_name)`, `workspaces(id,name,slug,created_by_user_id)`, `workspace_members(workspace_id,user_id,role)` PK `(workspace_id,user_id)`, `projects(id TEXT,workspace_id,owner_user_id,visibility,state JSONB,revision)`, plus `workspace_settings`, `user_settings`, `announcements`, `songs`, `templates`, `fonts`.
+- Item rows already render `data-idx` and `data-action="up|down|delete|collapse"` (editor.js:112–124). Other row types need a consistent `data-testid` convention added.
+- Existing tests: `vitest` + jsdom, config in `vite.config.js`, setup `vitest.setup.js`. Leave entirely intact.
+
+---
+
+## File structure (created this phase)
+
+- `playwright.config.ts` — two lanes (core, live) + setup/teardown projects, `webServer` spawns `python3 server.py`.
+- `tsconfig.e2e.json` — TS config scoped to `tests/e2e`.
+- `.env.e2e.example` — documents required test env vars (committed); `.env.e2e` is gitignored.
+- `tests/e2e/helpers/env.ts` — load + validate test env.
+- `tests/e2e/helpers/supabase-admin.ts` — service_role client; create/seed/delete ephemeral identity.
+- `tests/e2e/helpers/auth.setup.ts` — core + live setup specs (provision/sign-in, save storageState).
+- `tests/e2e/helpers/auth.teardown.ts` — delete ephemeral identity.
+- `tests/e2e/helpers/clock.ts` — `page.clock` wrappers for the known debounces/timers.
+- `tests/e2e/helpers/pdf.ts` — assert a Buffer is a valid PDF.
+- `tests/e2e/pages/AppShell.ts` — minimal page object: tab switching + readiness.
+- `tests/e2e/flows/smoke.spec.ts` — the end-to-end smoke (tagged `@core` and a `@live` variant).
+- `.github/workflows/e2e-core.yml` — PR-blocking core lane.
+- `.github/workflows/e2e-live.yml` — nightly/dispatch live lane.
+- Modified: `package.json` (scripts + devDeps), `.gitignore`, render sites for `data-testid`.
+
+---
+
+### Task 1: Install Playwright test runner and add scripts
+
+**Files:**
+- Modify: `package.json`
+- Modify: `.gitignore`
+
+- [ ] **Step 1: Add the test runner and scripts**
+
+Run:
+```bash
+npm install -D @playwright/test@^1.59.1 dotenv@^16.4.5
+npx playwright install --with-deps chromium
+```
+
+- [ ] **Step 2: Add npm scripts to `package.json`**
+
+Add these keys to the existing `"scripts"` object (keep `test`/`test:watch` unchanged):
+```json
+"test:e2e": "playwright test --project=core",
+"test:e2e:live": "playwright test --project=live",
+"test:e2e:ui": "playwright test --ui",
+"test:e2e:report": "playwright show-report"
+```
+
+- [ ] **Step 3: Ignore generated + secret artifacts**
+
+Append to `.gitignore`:
+```
+# Playwright E2E
+/.env.e2e
+/test-results/
+/playwright-report/
+/tests/e2e/.auth/
+/tests/e2e/recordings/*.local.har
+```
+
+- [ ] **Step 4: Verify the runner is available**
+
+Run: `npx playwright --version`
+Expected: prints `Version 1.59.x`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add package.json package-lock.json .gitignore
+git commit -m "test(e2e): add @playwright/test runner and scripts"
+```
+
+---
+
+### Task 2: Test env contract
+
+**Files:**
+- Create: `.env.e2e.example`
+- Create: `tests/e2e/helpers/env.ts`
+- Create: `tsconfig.e2e.json`
+
+- [ ] **Step 1: Document required env (committed example)**
+
+Create `.env.e2e.example`:
+```bash
+# Hosted Supabase TEST project (never production)
+SUPABASE_URL=https://YOUR_TEST_REF.supabase.co
+SUPABASE_ANON_KEY=eyJ...anon...
+SUPABASE_JWT_SECRET=your-test-jwt-secret
+SUPABASE_SERVICE_ROLE_KEY=eyJ...service_role...   # setup/teardown only
+DATABASE_URL=postgresql://postgres:pw@db.YOUR_TEST_REF.supabase.co:5432/postgres
+
+# Live lane only — the already-connected workspace account
+E2E_LIVE_EMAIL=worship@visaliacrc.com
+E2E_LIVE_PASSWORD=...
+
+# Optional: where the app is served during tests
+E2E_BASE_URL=http://127.0.0.1:8080
+```
+
+- [ ] **Step 2: Write the failing test for env loading**
+
+Create `tests/e2e/helpers/env.test.ts` (run with vitest):
+```ts
+import { describe, it, expect } from 'vitest';
+import { loadE2eEnv } from './env';
+
+describe('loadE2eEnv', () => {
+  it('throws a clear error when a required var is missing', () => {
+    expect(() => loadE2eEnv({}, ['SUPABASE_URL'])).toThrow(/SUPABASE_URL/);
+  });
+  it('returns the requested vars when present', () => {
+    const env = loadE2eEnv({ SUPABASE_URL: 'x', SUPABASE_ANON_KEY: 'y' }, [
+      'SUPABASE_URL',
+      'SUPABASE_ANON_KEY',
+    ]);
+    expect(env).toEqual({ SUPABASE_URL: 'x', SUPABASE_ANON_KEY: 'y' });
+  });
+});
+```
+
+- [ ] **Step 3: Run it to confirm it fails**
+
+Run: `npx vitest run tests/e2e/helpers/env.test.ts`
+Expected: FAIL — `Cannot find module './env'`.
+
+- [ ] **Step 4: Implement `env.ts`**
+
+Create `tests/e2e/helpers/env.ts`:
+```ts
+import { config as loadDotenv } from 'dotenv';
+
+let loaded = false;
+function ensureDotenv() {
+  if (!loaded) {
+    loadDotenv({ path: '.env.e2e' });
+    loaded = true;
+  }
+}
+
+export function loadE2eEnv<K extends string>(
+  source: Record<string, string | undefined>,
+  required: readonly K[],
+): Record<K, string> {
+  const out = {} as Record<K, string>;
+  const missing: string[] = [];
+  for (const key of required) {
+    const val = source[key];
+    if (!val) missing.push(key);
+    else out[key] = val;
+  }
+  if (missing.length) {
+    throw new Error(`Missing required E2E env var(s): ${missing.join(', ')}`);
+  }
+  return out;
+}
+
+export function e2eEnv<K extends string>(required: readonly K[]): Record<K, string> {
+  ensureDotenv();
+  return loadE2eEnv(process.env, required);
+}
+```
+
+- [ ] **Step 5: Add a TS config for the suite**
+
+Create `tsconfig.e2e.json`:
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["tests/e2e/**/*.ts", "playwright.config.ts"]
+}
+```
+
+- [ ] **Step 6: Run the env test to confirm it passes**
+
+Run: `npx vitest run tests/e2e/helpers/env.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add .env.e2e.example tests/e2e/helpers/env.ts tests/e2e/helpers/env.test.ts tsconfig.e2e.json
+git commit -m "test(e2e): add validated test env contract"
+```
+
+---
+
+### Task 3: Supabase admin helper — provision & destroy an isolated identity
+
+> The ephemeral identity is the core lane's isolation boundary. `service_role` bypasses RLS, so we create the user, a dedicated workspace, the membership row, and a defensive `profiles` upsert (works whether or not an `auth.users` trigger mirrors profiles).
+
+**Files:**
+- Create: `tests/e2e/helpers/supabase-admin.ts`
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `tests/e2e/helpers/supabase-admin.test.ts` (run with vitest; requires `.env.e2e` pointing at the TEST project):
+```ts
+import { describe, it, expect, afterAll } from 'vitest';
+import { createEphemeralIdentity, destroyEphemeralIdentity, type EphemeralIdentity } from './supabase-admin';
+
+const RUN = process.env.SUPABASE_SERVICE_ROLE_KEY ? describe : describe.skip;
+let id: EphemeralIdentity;
+
+RUN('ephemeral identity lifecycle', () => {
+  it('creates a user + workspace + membership', async () => {
+    id = await createEphemeralIdentity('lifecycle');
+    expect(id.userId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(id.workspaceId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(id.email).toContain('@');
+    expect(id.password.length).toBeGreaterThan(12);
+  });
+  afterAll(async () => { if (id) await destroyEphemeralIdentity(id); });
+});
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `npx vitest run tests/e2e/helpers/supabase-admin.test.ts`
+Expected: FAIL — `Cannot find module './supabase-admin'`.
+
+- [ ] **Step 3: Implement `supabase-admin.ts`**
+
+Create `tests/e2e/helpers/supabase-admin.ts`:
+```ts
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { randomUUID } from 'node:crypto';
+import { e2eEnv } from './env';
+
+export interface EphemeralIdentity {
+  userId: string;
+  workspaceId: string;
+  email: string;
+  password: string;
+}
+
+function admin(): SupabaseClient {
+  const env = e2eEnv(['SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY'] as const);
+  return createClient(env.SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+}
+
+/** Create an isolated user + workspace + owner membership. RLS-bypassing (service_role). */
+export async function createEphemeralIdentity(label: string): Promise<EphemeralIdentity> {
+  const sb = admin();
+  const tag = randomUUID().slice(0, 8);
+  const email = `e2e-${label}-${tag}@e2e.bulletin.test`;
+  const password = `E2e-${randomUUID()}`;
+
+  const { data: created, error: userErr } = await sb.auth.admin.createUser({
+    email, password, email_confirm: true,
+  });
+  if (userErr || !created.user) throw new Error(`createUser failed: ${userErr?.message}`);
+  const userId = created.user.id;
+
+  // Defensive: ensure a profiles row exists regardless of trigger behavior.
+  await sb.from('profiles').upsert({ id: userId, email }, { onConflict: 'id' });
+
+  const { data: ws, error: wsErr } = await sb
+    .from('workspaces')
+    .insert({ name: `E2E ${tag}`, slug: `e2e-${tag}`, created_by_user_id: userId })
+    .select('id')
+    .single();
+  if (wsErr || !ws) throw new Error(`workspace insert failed: ${wsErr?.message}`);
+  const workspaceId = ws.id as string;
+
+  const { error: memErr } = await sb
+    .from('workspace_members')
+    .insert({ workspace_id: workspaceId, user_id: userId, role: 'owner' });
+  if (memErr) throw new Error(`membership insert failed: ${memErr.message}`);
+
+  return { userId, workspaceId, email, password };
+}
+
+export async function destroyEphemeralIdentity(id: EphemeralIdentity): Promise<void> {
+  const sb = admin();
+  // FK cleanup first (workspace-scoped rows), then workspace, then auth user.
+  await sb.from('projects').delete().eq('workspace_id', id.workspaceId);
+  await sb.from('workspace_members').delete().eq('workspace_id', id.workspaceId);
+  await sb.from('workspaces').delete().eq('id', id.workspaceId);
+  await sb.auth.admin.deleteUser(id.userId);
+}
+```
+
+- [ ] **Step 4: Run the lifecycle test against the test project**
+
+Run: `npx vitest run tests/e2e/helpers/supabase-admin.test.ts`
+Expected: PASS (creates + deletes a real user/workspace). If a column name differs from the migration, fix the literal here and re-run.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/e2e/helpers/supabase-admin.ts tests/e2e/helpers/supabase-admin.test.ts
+git commit -m "test(e2e): add service_role helper to provision/destroy isolated identity"
+```
+
+---
+
+### Task 4: Determinism helpers (page.clock wrappers)
+
+**Files:**
+- Create: `tests/e2e/helpers/clock.ts`
+
+- [ ] **Step 1: Implement the clock helper**
+
+Create `tests/e2e/helpers/clock.ts`:
+```ts
+import type { Page } from '@playwright/test';
+
+/** App debounce/timer constants (verified in src/js). */
+export const TIMERS = {
+  previewDebounceMs: 250,
+  persistDebounceMs: 350,
+  presenceHeartbeatMs: 30_000,
+  filesRefreshMs: 30_000,
+  calCacheMs: 15 * 60 * 1000,
+} as const;
+
+/** Install a controllable clock. Call before navigation. */
+export async function installClock(page: Page): Promise<void> {
+  await page.clock.install();
+}
+
+/** Advance past the autosave debounce so a persist POST fires deterministically. */
+export async function settlePersist(page: Page): Promise<void> {
+  await page.clock.runFor(TIMERS.previewDebounceMs + TIMERS.persistDebounceMs + 50);
+}
+
+/** Advance one presence heartbeat interval. */
+export async function tickPresence(page: Page): Promise<void> {
+  await page.clock.runFor(TIMERS.presenceHeartbeatMs + 100);
+}
+```
+
+- [ ] **Step 2: Typecheck the helper**
+
+Run: `npx tsc -p tsconfig.e2e.json --noEmit`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/e2e/helpers/clock.ts
+git commit -m "test(e2e): add page.clock determinism helpers"
+```
+
+---
+
+### Task 5: PDF assertion helper
+
+**Files:**
+- Create: `tests/e2e/helpers/pdf.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/e2e/helpers/pdf.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest';
+import { assertValidPdf } from './pdf';
+
+describe('assertValidPdf', () => {
+  it('accepts a minimal PDF buffer', () => {
+    const buf = Buffer.from('%PDF-1.4\n1 0 obj<<>>endobj\n%%EOF');
+    expect(() => assertValidPdf(buf)).not.toThrow();
+  });
+  it('rejects non-PDF bytes', () => {
+    expect(() => assertValidPdf(Buffer.from('<html></html>'))).toThrow(/not a PDF/i);
+  });
+  it('rejects an empty buffer', () => {
+    expect(() => assertValidPdf(Buffer.alloc(0))).toThrow(/empty/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `npx vitest run tests/e2e/helpers/pdf.test.ts`
+Expected: FAIL — `Cannot find module './pdf'`.
+
+- [ ] **Step 3: Implement `pdf.ts`**
+
+Create `tests/e2e/helpers/pdf.ts`:
+```ts
+/** Throws unless `buf` looks like a valid, non-empty PDF. Returns the page count (best-effort). */
+export function assertValidPdf(buf: Buffer): number {
+  if (!buf || buf.length === 0) throw new Error('PDF buffer is empty');
+  const head = buf.subarray(0, 5).toString('latin1');
+  if (head !== '%PDF-') throw new Error(`Buffer is not a PDF (header was "${head}")`);
+  const tail = buf.subarray(-1024).toString('latin1');
+  if (!tail.includes('%%EOF')) throw new Error('PDF is missing %%EOF trailer');
+  const matches = buf.toString('latin1').match(/\/Type\s*\/Page[^s]/g);
+  return matches ? matches.length : 0;
+}
+```
+
+- [ ] **Step 4: Run it to confirm it passes**
+
+Run: `npx vitest run tests/e2e/helpers/pdf.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/e2e/helpers/pdf.ts tests/e2e/helpers/pdf.test.ts
+git commit -m "test(e2e): add PDF validity assertion helper"
+```
+
+---
+
+### Task 6: Add `data-testid` convention to dynamic row renders
+
+> Convention: every repeated row gets `data-testid="<area>-row"` plus a numeric `data-index`. Item cards already expose `data-idx`; we add `data-testid` alongside. Apply the SAME one-line pattern at each render site.
+
+**Files:**
+- Modify: `src/js/editor.js:112` (order-of-worship item card)
+- Modify: `src/js/announcements.js` (announcement card render)
+- Modify: `src/js/staff.js` (staff row render)
+- Modify: `src/js/calendar.js` (calendar event row render)
+- Modify: `src/js/songs.js` (song-db list item render)
+- Modify: `src/js/editor.js` (welcome item render, volunteer-roles render — locate the row-creating element in each)
+
+- [ ] **Step 1: Anchor example — item card (editor.js)**
+
+At `src/js/editor.js:112`, immediately after `card.dataset.idx = idx;`, add:
+```js
+    card.dataset.testid = 'item-row';
+    card.dataset.index = idx;
+```
+
+- [ ] **Step 2: Apply the same pattern to each other row render**
+
+For each file above, find the element created per row (the `document.createElement(...)` whose result is appended to the list container) and add the two lines, substituting the area name:
+```js
+    rowEl.dataset.testid = 'ann-row';      // announcements.js
+    rowEl.dataset.index = i;
+```
+```js
+    rowEl.dataset.testid = 'staff-row';    // staff.js
+    rowEl.dataset.index = i;
+```
+```js
+    rowEl.dataset.testid = 'cal-event-row'; // calendar.js
+    rowEl.dataset.index = i;
+```
+```js
+    rowEl.dataset.testid = 'song-db-row';  // songs.js
+    rowEl.dataset.index = i;
+```
+```js
+    rowEl.dataset.testid = 'welcome-row';  // editor.js welcome render
+    rowEl.dataset.index = i;
+```
+```js
+    rowEl.dataset.testid = 'vr-row';       // editor.js volunteer-roles render
+    rowEl.dataset.index = i;
+```
+Use the loop index variable already present at each site (`idx`, `i`, etc.).
+
+- [ ] **Step 3: Confirm no behavior changed (unit tests still green)**
+
+Run: `npm test`
+Expected: existing vitest suite PASSES unchanged.
+
+- [ ] **Step 4: Confirm the app still loads (manual quick check)**
+
+Run: `APP_MODE=desktop python3 server.py` in one terminal, open `http://localhost:8765`, confirm the editor renders. Stop the server.
+Expected: rows render normally; `data-testid` attributes present in DevTools.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/js/editor.js src/js/announcements.js src/js/staff.js src/js/calendar.js src/js/songs.js
+git commit -m "feat(test-seam): add data-testid/data-index to dynamic row renders"
+```
+
+---
+
+### Task 7: Playwright config — two lanes, setup/teardown, webServer
+
+**Files:**
+- Create: `playwright.config.ts`
+
+- [ ] **Step 1: Implement the config**
+
+Create `playwright.config.ts`:
+```ts
+import { defineConfig, devices } from '@playwright/test';
+import { config as loadDotenv } from 'dotenv';
+
+loadDotenv({ path: '.env.e2e' });
+
+const BASE_URL = process.env.E2E_BASE_URL ?? 'http://127.0.0.1:8080';
+
+export default defineConfig({
+  testDir: 'tests/e2e',
+  fullyParallel: false,            // server.py is a shared single instance this phase
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: [['html', { open: 'never' }], ['list']],
+  use: {
+    baseURL: BASE_URL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  webServer: {
+    command: 'python3 server.py',
+    url: `${BASE_URL}/api/health`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+    env: {
+      APP_MODE: 'server',
+      DATABASE_URL: process.env.DATABASE_URL ?? '',
+      SUPABASE_URL: process.env.SUPABASE_URL ?? '',
+      SUPABASE_ANON_KEY: process.env.SUPABASE_ANON_KEY ?? '',
+      SUPABASE_JWT_SECRET: process.env.SUPABASE_JWT_SECRET ?? '',
+    },
+  },
+  projects: [
+    { name: 'core-setup', testMatch: /helpers\/auth\.setup\.ts/, grep: /@core-setup/, teardown: 'core-teardown' },
+    { name: 'core-teardown', testMatch: /helpers\/auth\.teardown\.ts/ },
+    { name: 'live-setup', testMatch: /helpers\/auth\.setup\.ts/, grep: /@live-setup/ },
+    {
+      name: 'core',
+      grep: /@core/,
+      dependencies: ['core-setup'],
+      use: { ...devices['Desktop Chrome'], storageState: 'tests/e2e/.auth/core.json' },
+    },
+    {
+      name: 'live',
+      grep: /@live/,
+      dependencies: ['live-setup'],
+      use: { ...devices['Desktop Chrome'], storageState: 'tests/e2e/.auth/live.json' },
+    },
+  ],
+});
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npx tsc -p tsconfig.e2e.json --noEmit`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add playwright.config.ts
+git commit -m "test(e2e): add two-lane Playwright config with webServer + setup/teardown"
+```
+
+---
+
+### Task 8: Auth setup & teardown projects
+
+> Setup signs in via supabase-js in a real browser context so we capture whatever localStorage key supabase-js uses, then save `storageState`. Core uses the ephemeral identity (ids written to disk for teardown); live uses `worship@`.
+
+**Files:**
+- Create: `tests/e2e/helpers/auth.setup.ts`
+- Create: `tests/e2e/helpers/auth.teardown.ts`
+
+- [ ] **Step 1: Implement `auth.setup.ts`**
+
+Create `tests/e2e/helpers/auth.setup.ts`:
+```ts
+import { test as setup, expect } from '@playwright/test';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { e2eEnv } from './env';
+import { createEphemeralIdentity } from './supabase-admin';
+
+const CORE_STATE = 'tests/e2e/.auth/core.json';
+const LIVE_STATE = 'tests/e2e/.auth/live.json';
+const CORE_IDS = 'tests/e2e/.auth/core-ids.json';
+
+/** Sign in through supabase-js in the page, then save storageState. */
+async function signInAndSave(page: import('@playwright/test').Page, email: string, password: string, statePath: string) {
+  await page.goto('/');
+  // Wait for the app's supabase client + config to be available.
+  await page.waitForFunction(() => !!(globalThis as any).BULLETIN_SUPABASE_CONFIG);
+  const ok = await page.evaluate(async ({ email, password }) => {
+    const cfg = (globalThis as any).BULLETIN_SUPABASE_CONFIG;
+    const { createClient } = await import('https://esm.sh/@supabase/supabase-js@2');
+    const sb = createClient(cfg.url, cfg.anonKey);
+    const { error } = await sb.auth.signInWithPassword({ email, password });
+    return !error;
+  }, { email, password });
+  if (!ok) throw new Error(`signInWithPassword failed for ${email}`);
+  await page.reload();
+  await expect.poll(async () =>
+    (await page.request.get('/api/me')).status(),
+  ).toBe(200);
+  mkdirSync('tests/e2e/.auth', { recursive: true });
+  await page.context().storageState({ path: statePath });
+}
+
+setup('@core-setup provision ephemeral identity', async ({ page }) => {
+  const id = await createEphemeralIdentity('core');
+  mkdirSync('tests/e2e/.auth', { recursive: true });
+  writeFileSync(CORE_IDS, JSON.stringify(id));
+  await signInAndSave(page, id.email, id.password, CORE_STATE);
+});
+
+setup('@live-setup sign in worship account', async ({ page }) => {
+  const env = e2eEnv(['E2E_LIVE_EMAIL', 'E2E_LIVE_PASSWORD'] as const);
+  await signInAndSave(page, env.E2E_LIVE_EMAIL, env.E2E_LIVE_PASSWORD, LIVE_STATE);
+});
+```
+
+- [ ] **Step 2: Implement `auth.teardown.ts`**
+
+Create `tests/e2e/helpers/auth.teardown.ts`:
+```ts
+import { test as teardown } from '@playwright/test';
+import { readFileSync, existsSync, rmSync } from 'node:fs';
+import { destroyEphemeralIdentity } from './supabase-admin';
+
+const CORE_IDS = 'tests/e2e/.auth/core-ids.json';
+
+teardown('destroy ephemeral identity', async () => {
+  if (!existsSync(CORE_IDS)) return;
+  const id = JSON.parse(readFileSync(CORE_IDS, 'utf8'));
+  await destroyEphemeralIdentity(id);
+  rmSync(CORE_IDS, { force: true });
+});
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npx tsc -p tsconfig.e2e.json --noEmit`
+Expected: no errors.
+
+- [ ] **Step 4: Smoke-run setup only (against test project)**
+
+Run: `npx playwright test --project=core-setup`
+Expected: PASS — creates `tests/e2e/.auth/core.json` and `core-ids.json`; teardown then deletes the identity. If the `esm.sh` import is blocked in CI, switch to bundling supabase-js via the app's own `/src/js/supabase-browser.js` (note for live-lane network policy).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/e2e/helpers/auth.setup.ts tests/e2e/helpers/auth.teardown.ts
+git commit -m "test(e2e): add auth setup/teardown for core + live lanes"
+```
+
+---
+
+### Task 9: AppShell page object
+
+**Files:**
+- Create: `tests/e2e/pages/AppShell.ts`
+
+- [ ] **Step 1: Implement the page object**
+
+Create `tests/e2e/pages/AppShell.ts`:
+```ts
+import { type Page, type Locator, expect } from '@playwright/test';
+
+const TABS = {
+  editor: 'page-editor',
+  files: 'page-files',
+  songdb: 'page-songdb',
+  format: 'page-format',
+  templates: 'page-templates',
+  settings: 'page-settings',
+} as const;
+export type TabName = keyof typeof TABS;
+
+export class AppShell {
+  constructor(private readonly page: Page) {}
+
+  async goto(): Promise<void> {
+    await this.page.goto('/');
+    await expect(this.page.locator('.tab-bar')).toBeVisible();
+  }
+
+  tab(name: TabName): Locator {
+    return this.page.locator(`[data-tab="${TABS[name]}"]`);
+  }
+
+  async switchTo(name: TabName): Promise<void> {
+    await this.tab(name).click();
+    await expect(this.tab(name)).toHaveAttribute('aria-selected', 'true');
+  }
+
+  /**
+   * Assert the server-mode session is authenticated. Uses UI signals, NOT
+   * page.request — page.request is a separate context that does not run the
+   * app's JS, so it never attaches the supabase Bearer token that apiFetch adds.
+   */
+  async expectAuthenticated(): Promise<void> {
+    await expect(this.page.locator('#login-screen')).toBeHidden();
+    await expect(this.page.locator('#user-info')).toBeVisible();
+  }
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npx tsc -p tsconfig.e2e.json --noEmit`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/e2e/pages/AppShell.ts
+git commit -m "test(e2e): add AppShell page object"
+```
+
+---
+
+### Task 10: The end-to-end smoke spec (both lanes green)
+
+> Proves the whole harness: real server boot, authenticated session, tab nav, create+persist a project, export a valid PDF. The `@live` variant additionally asserts the real PCO connection is present (read-only).
+
+**Files:**
+- Create: `tests/e2e/flows/smoke.spec.ts`
+
+- [ ] **Step 1: Write the smoke spec**
+
+Create `tests/e2e/flows/smoke.spec.ts`:
+```ts
+import { test, expect } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+import { AppShell } from '../pages/AppShell';
+import { installClock, settlePersist } from '../helpers/clock';
+import { assertValidPdf } from '../helpers/pdf';
+
+test.describe('@core harness smoke', () => {
+  test('boots, authenticates, navigates, persists a project, exports PDF', async ({ page }) => {
+    await installClock(page);
+    const shell = new AppShell(page);
+    await shell.goto();
+    await shell.expectAuthenticated();
+
+    for (const tab of ['files', 'songdb', 'format', 'templates', 'settings', 'editor'] as const) {
+      await shell.switchTo(tab);
+    }
+
+    // Create + persist a project via the UI.
+    await shell.switchTo('editor');
+    await page.locator('#bulletin-title').fill('E2E Smoke Bulletin');
+    await page.locator('#svc-title').fill('Smoke Service');
+    await page.locator('#add-item-btn').click();
+    await page.locator('[data-testid="item-row"][data-index="0"] .item-title-input').fill('Welcome');
+    await settlePersist(page);
+
+    // Confirm it persisted by reloading and finding it in Files.
+    await page.reload();
+    await shell.switchTo('files');
+    await expect(page.locator('#files-list')).toContainText('E2E Smoke Bulletin');
+
+    // Export a PDF through the real UI button (authenticated, via app JS) and
+    // assert the downloaded bytes are a valid PDF.
+    await shell.switchTo('editor');
+    const printBtn = page.locator('#btn-print');
+    await expect(printBtn).toBeEnabled();
+    const downloadPromise = page.waitForEvent('download');
+    await printBtn.click();
+    const download = await downloadPromise;
+    const filePath = await download.path();
+    expect(filePath).toBeTruthy();
+    assertValidPdf(readFileSync(filePath!));
+  });
+});
+
+test.describe('@live real-integration smoke', () => {
+  test('worship account is authenticated and PCO is connected', async ({ page }) => {
+    const shell = new AppShell(page);
+    await shell.goto();
+    await shell.expectAuthenticated();
+    // PCO connected → the import view (hidden until connected) is visible.
+    // Read-only: we never trigger an import here.
+    await page.locator('#editor-toolbar-sync').click();
+    await expect(page.locator('#pco-import-view')).toBeVisible();
+  });
+});
+```
+
+- [ ] **Step 2: Run the core smoke**
+
+Run: `npm run test:e2e`
+Expected: `core-setup` runs, then the `@core` smoke PASSES, then `core-teardown` deletes the identity.
+
+- [ ] **Step 3: Run the live smoke**
+
+Run: `npm run test:e2e:live`
+Expected: `live-setup` signs in as `worship@`, then the `@live` smoke PASSES. (If the PCO token has lapsed, this is the expected loud signal — re-connect per runbook.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/e2e/flows/smoke.spec.ts
+git commit -m "test(e2e): add two-lane end-to-end harness smoke"
+```
+
+---
+
+### Task 11: CI — core gate workflow
+
+**Files:**
+- Create: `.github/workflows/e2e-core.yml`
+
+- [ ] **Step 1: Implement the workflow**
+
+Create `.github/workflows/e2e-core.yml`:
+```yaml
+name: E2E Core (PR gate)
+on:
+  push:
+    branches: [main]
+  pull_request:
+jobs:
+  e2e-core:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20', cache: 'npm' }
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.12' }
+      - run: pip install -r requirements.txt
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - name: Run core lane
+        env:
+          CI: 'true'
+          SUPABASE_URL: ${{ secrets.E2E_SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.E2E_SUPABASE_ANON_KEY }}
+          SUPABASE_JWT_SECRET: ${{ secrets.E2E_SUPABASE_JWT_SECRET }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.E2E_SUPABASE_SERVICE_ROLE_KEY }}
+          DATABASE_URL: ${{ secrets.E2E_DATABASE_URL }}
+        run: npx playwright test --project=core
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with: { name: playwright-report, path: playwright-report/, retention-days: 7 }
+```
+
+- [ ] **Step 2: Validate YAML locally**
+
+Run: `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/e2e-core.yml')); print('ok')"`
+Expected: `ok`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/e2e-core.yml
+git commit -m "ci(e2e): add core lane PR gate workflow"
+```
+
+---
+
+### Task 12: CI — live lane workflow
+
+**Files:**
+- Create: `.github/workflows/e2e-live.yml`
+
+- [ ] **Step 1: Implement the workflow**
+
+Create `.github/workflows/e2e-live.yml`:
+```yaml
+name: E2E Live (real integrations)
+on:
+  schedule:
+    - cron: '0 9 * * *'   # nightly 09:00 UTC
+  workflow_dispatch:
+jobs:
+  e2e-live:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20', cache: 'npm' }
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.12' }
+      - run: pip install -r requirements.txt
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - name: Run live lane
+        env:
+          CI: 'true'
+          SUPABASE_URL: ${{ secrets.E2E_SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.E2E_SUPABASE_ANON_KEY }}
+          SUPABASE_JWT_SECRET: ${{ secrets.E2E_SUPABASE_JWT_SECRET }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.E2E_SUPABASE_SERVICE_ROLE_KEY }}
+          DATABASE_URL: ${{ secrets.E2E_DATABASE_URL }}
+          E2E_LIVE_EMAIL: ${{ secrets.E2E_LIVE_EMAIL }}
+          E2E_LIVE_PASSWORD: ${{ secrets.E2E_LIVE_PASSWORD }}
+        run: npx playwright test --project=live
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with: { name: playwright-report-live, path: playwright-report/, retention-days: 14 }
+```
+
+- [ ] **Step 2: Validate YAML locally**
+
+Run: `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/e2e-live.yml')); print('ok')"`
+Expected: `ok`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/e2e-live.yml
+git commit -m "ci(e2e): add live lane scheduled workflow"
+```
+
+---
+
+## Phase 1 exit criteria
+
+- `npm run test:e2e` is green locally: ephemeral identity provisioned → smoke passes → identity destroyed.
+- `npm run test:e2e:live` is green locally against `worship@`.
+- `npm test` (vitest) still green — no app behavior changed.
+- Both CI workflows present and YAML-valid; core gate runs on PRs.
+- Secrets documented in `.env.e2e.example`; real values added to GitHub Secrets (`E2E_*`).
+
+---
+
+## Roadmap — subsequent phases (each becomes its own plan)
+
+These are intentionally NOT expanded here; each will be authored as a standalone plan once Phase 1 lands and the patterns/schema unknowns are resolved.
+
+- **Phase 2 — Page Object layer.** One typed page object per area: `EditorPage`, `ProjectsPage`, `PcoPanel`, `CalendarPanel`, `SongDbPage`, `FormatPage`, `TemplatesPage`, `SettingsPage`, `AnnouncementsPanel`, `StaffPanel`, `VolunteerRolesPanel`, `PreviewPane`, `AuthFlow`. Each exposes accessors keyed off the `data-testid` convention from Task 6.
+- **Phase 3 — Golden-path flows** (spec §6 flows): PCO import→edit→autosave→save-version→export; build-from-scratch; bulk export; calendar render; conflict resolution. Core lane uses recorded PCO/Google HARs; introduce `tests/e2e/helpers/record-replay.ts` (`routeFromHAR`) here, recorded by the live lane.
+- **Phase 4 — Exhaustive per-feature specs** filling every coverage-matrix row (spec §6). One spec file per area; a checklist tracks matrix completion.
+- **Phase 5 — Fixture auto-refresh + hardening.** Live lane re-records HARs and opens a PR on diff; flake-quarantine policy; optional thin Electron boot-smoke (deferred from v1 per spec §9).

--- a/docs/superpowers/plans/2026-06-05-e2e-playwright-foundation.md
+++ b/docs/superpowers/plans/2026-06-05-e2e-playwright-foundation.md
@@ -106,8 +106,9 @@ git commit -m "test(e2e): add @playwright/test runner and scripts"
 
 Create `.env.e2e.example`:
 ```bash
-# Hosted Supabase TEST project (never production)
-SUPABASE_URL=https://YOUR_TEST_REF.supabase.co
+# The single hosted Supabase project (the same one worship@ lives in).
+# Both lanes use it; the core lane isolates via ephemeral e2e- identities.
+SUPABASE_URL=https://YOUR_REF.supabase.co
 SUPABASE_ANON_KEY=eyJ...anon...
 SUPABASE_JWT_SECRET=your-test-jwt-secret
 SUPABASE_SERVICE_ROLE_KEY=eyJ...service_role...   # setup/teardown only
@@ -311,6 +312,27 @@ export async function destroyEphemeralIdentity(id: EphemeralIdentity): Promise<v
   await sb.from('workspace_members').delete().eq('workspace_id', id.workspaceId);
   await sb.from('workspaces').delete().eq('id', id.workspaceId);
   await sb.auth.admin.deleteUser(id.userId);
+}
+
+/**
+ * Safety net for the single-live-project model: delete any `e2e-`-prefixed
+ * leftovers a prior failed teardown left behind. ONLY touches `e2e-` rows, so it
+ * can never affect real users/workspaces. Runs at the start of each setup.
+ */
+export async function sweepStaleEphemeralIdentities(): Promise<void> {
+  const sb = admin();
+  // Workspaces created by the suite are named "E2E <tag>" / slug "e2e-<tag>".
+  const { data: stale } = await sb.from('workspaces').select('id').like('slug', 'e2e-%');
+  for (const ws of stale ?? []) {
+    await sb.from('projects').delete().eq('workspace_id', ws.id);
+    await sb.from('workspace_members').delete().eq('workspace_id', ws.id);
+    await sb.from('workspaces').delete().eq('id', ws.id);
+  }
+  // Delete orphaned e2e- auth users (paginate; emails carry the e2e- prefix).
+  const { data: list } = await sb.auth.admin.listUsers({ perPage: 1000 });
+  for (const u of list?.users ?? []) {
+    if (u.email?.startsWith('e2e-')) await sb.auth.admin.deleteUser(u.id);
+  }
 }
 ```
 
@@ -597,7 +619,7 @@ Create `tests/e2e/helpers/auth.setup.ts`:
 import { test as setup, expect } from '@playwright/test';
 import { writeFileSync, mkdirSync } from 'node:fs';
 import { e2eEnv } from './env';
-import { createEphemeralIdentity } from './supabase-admin';
+import { createEphemeralIdentity, sweepStaleEphemeralIdentities } from './supabase-admin';
 
 const CORE_STATE = 'tests/e2e/.auth/core.json';
 const LIVE_STATE = 'tests/e2e/.auth/live.json';
@@ -625,6 +647,7 @@ async function signInAndSave(page: import('@playwright/test').Page, email: strin
 }
 
 setup('@core-setup provision ephemeral identity', async ({ page }) => {
+  await sweepStaleEphemeralIdentities(); // remove any leftovers from a prior failed run
   const id = await createEphemeralIdentity('core');
   mkdirSync('tests/e2e/.auth', { recursive: true });
   writeFileSync(CORE_IDS, JSON.stringify(id));

--- a/docs/superpowers/plans/2026-06-05-e2e-playwright-phases-2-5.md
+++ b/docs/superpowers/plans/2026-06-05-e2e-playwright-phases-2-5.md
@@ -1,0 +1,64 @@
+# E2E Suite — Phases 2–5 Implementation Plan (Full Coverage)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Each slice is verified by RUNNING the lane (`npm run test:e2e` / `:live`) against the real app + Supabase, not just typecheck. Steps use `- [ ]`.
+
+**Goal:** Grow the verified Phase-1 harness into exhaustive coverage of every tab, control, field, route, render path, export, and persistence flow — the "test everything, forever" target from the spec.
+
+**Approach — verified vertical slices.** Rather than build all Page Objects, then all specs, we deliver one **feature area at a time**: its Page Object **plus** its exhaustive spec, run green against the live app before moving on. This makes every increment independently reviewable and proven, and folds the spec's Phase 2 (page objects) and Phase 4 (exhaustive matrix) into per-area units. Phase 3 (golden flows) is a capstone; Phase 5 (record/replay + live PCO/Google specs + fixture refresh) is infra.
+
+**Reference:** design spec `docs/superpowers/specs/2026-06-05-e2e-playwright-suite-design.md`; Phase 1 plan `2026-06-05-e2e-playwright-foundation.md`.
+
+---
+
+## Runtime patterns learned in Phase 1 (apply in every slice)
+
+- **App readiness:** `AppShell.goto()` already waits for `[data-tab=page-editor]` aria-selected — the app wires UI after `load`. Reuse it; never interact before it.
+- **No fake clock:** `page.clock.install()` stalls the app's timer-driven legacy-script loader. Wait on real network (`waitForResponse`) or UI state instead.
+- **Autosave gating:** edits only persist once a project is active (`projects.js:345`). A fresh user must Save first (File menu → `#bulletin-title` → `#project-save-btn`).
+- **Collapsed `<details>` menus:** File `#editor-toolbar-file`, Sync `#editor-toolbar-sync`, Document `#editor-toolbar-document` — click the `summary` to open before touching fields inside.
+- **Editor sidebar sections** (Welcome, Announcements, Order of Worship, Calendar, Volunteers, Volunteer Roles, Staff) render as collapsible cards; expanding is required before their inner controls are visible (slice 1 establishes the helper).
+- **Dynamic rows** carry `data-testid="<area>-row"` + `data-index` (Phase 1 seam).
+- **Writes hit the live project** → every spec must create only disposable data within the run's ephemeral workspace (core lane) and clean up project rows via teardown (already destroys the whole ephemeral workspace).
+
+---
+
+## Shared infrastructure (slice 0)
+
+**Files:** `tests/e2e/pages/BasePanel.ts` (or helpers) — utilities used across POs:
+- `openToolbarMenu(name)` — open File/Sync/Document `<details>` by clicking its summary; assert panel visible.
+- `expandSection(label)` — expand an editor sidebar section card by its heading; assert inner controls visible.
+- `createAndSaveProject(name)` — the canonical "make a persistable project" flow (File → title → Save → await POST). Most specs need an active project first.
+- `row(area, index)` — locator helper for `[data-testid="<area>-row"][data-index="N"]`.
+
+Verify slice 0 by refactoring the existing smoke to use these helpers and re-running core lane green.
+
+---
+
+## Per-area slices (each = Page Object + exhaustive spec, run green)
+
+Each slice: (1) inspect that area's real DOM/interaction in index.html + its JS module; (2) write `pages/<Area>Page.ts`; (3) write `features/<area>.spec.ts` covering every control/field/route from the coverage matrix (spec §6); (4) run the lane until green; (5) commit.
+
+1. **Editor / Order of Worship** (`editor.js`): add item, every item type (song/liturgy/label/section/note/media via `.item-type-sel`), title + detail edit, per-item format override, collapse, move up/down, drag-reorder, delete, add page break. Assert preview reflects changes.
+2. **Projects / Files** (`projects.js`): new, save, save-new-version, rename, delete, open from list, import JSON, bulk select/all/clear, bulk download JSON/PDF/ProPresenter, delete-selected. Server-mode subtabs.
+3. **Song Database** (`songs.js`): add manually, edit, delete, search, all sorts, source filter, paste-from-clipboard (+ fallback dialog), export/import JSON, clear-all. ProPresenter import dialogs (disclaimer→import→preview) — file upload fixtures.
+4. **Format** (`formatting.js`): page-size select, per-type cards for every type, filter, save, reset, override-precedence assertion (computed style on rendered preview element — see memory feedback_test_contract_not_surface).
+5. **Templates** (`templates`/designer): apply built-in (dialog confirm/cancel), designer open/edit-element/name/save/save-as/export/back, import, new, fonts upload/list/delete.
+6. **Settings** (`staff.js`/`calendar.js`/branding/update): identity display name, church name, give URL, logo upload/clear, calendar (iCal URLs save/reset, exclude save), serving-team filter, song-db export/import/clear, updates (check, banner). Calendar manual add/edit/delete event lives in the editor Calendar section.
+7. **Editor sub-sections:** Welcome, Announcements (title/body/url/page-break), Volunteer Roles, Staff (name/role/email, move, remove). Each add/edit/remove + preview assertion.
+8. **Auth & server-mode behaviors:** login screen states; ownership/read-only (second ephemeral user views a workspace project → banner + disabled saves + Duplicate); 409 conflict dialog (two contexts editing → all three resolution buttons); stale-revision poll; presence badge. Needs multi-context tests.
+
+## Phase 3 — Golden flows (`flows/`)
+- Build-from-scratch → all sections populated → save → export PDF (page-count + preview snapshot).
+- Bulk export (JSON + PDF + ProPresenter) of multiple projects.
+- (live lane) PCO import → edit → save → export, read-only.
+
+## Phase 5 — Live integrations + fixture refresh
+- `helpers/record-replay.ts` (`routeFromHAR`): live lane records PCO/Google; core lane replays so PCO/calendar specs run deterministically in the gate (ephemeral users have no connected tokens).
+- Live-lane PCO + Google Calendar read-only specs (service types/plans/items load; calendar events render).
+- Fixture auto-refresh: live lane re-records HARs and opens a PR on diff.
+- Optional: thin Electron boot-smoke (deferred from v1).
+
+---
+
+## Definition of done (per the spec's coverage matrix §6)
+Every matrix row maps to a passing test tagged `@core` or `@live`. Track completion area-by-area. `npm test` (vitest) stays green throughout. Core lane remains the PR gate; live lane stays soft.

--- a/docs/superpowers/specs/2026-06-05-e2e-playwright-suite-design.md
+++ b/docs/superpowers/specs/2026-06-05-e2e-playwright-suite-design.md
@@ -32,7 +32,7 @@ flaky gate gets ignored — strictly worse than no gate.
 | | **Lane A — Core (PR gate)** | **Lane B — Live (real integrations)** |
 |---|---|---|
 | Backend | Real `server.py`, server mode | Real `server.py`, server mode |
-| Supabase | Real hosted test project, **ephemeral isolated user/workspace per run** | Real hosted test project, `worship@visaliacrc.com` account |
+| Supabase | The single live project, **ephemeral isolated user/workspace per run** | The single live project, `worship@visaliacrc.com` account |
 | PCO / Google | **Recorded/replayed** real responses (deterministic) | **Live API**, read-only, using the workspace's already-connected tokens |
 | PDF | Real headless Chrome | Real headless Chrome |
 | Runs | Every push/PR, **blocking** | Nightly cron + `workflow_dispatch` + `run-live` PR label, **soft-report** |
@@ -46,13 +46,20 @@ Properties:
 - **The interactive OAuth consent screen is never automated.** Lane B inherits the
   `worship@` workspace's already-connected tokens; Lane A's ephemeral users have nothing
   connected, so their PCO/Google paths are served from recordings.
-- **Isolation via the app's own multitenancy.** Both lanes hit the real hosted Supabase
-  project. Lane A stays deterministic because each CI run gets its own throwaway user +
-  workspace; RLS guarantees parallel runs cannot see each other's rows.
+- **Isolation via the app's own multitenancy.** There is a **single** hosted Supabase
+  project (the one `worship@` lives in); both lanes use it. Lane A stays deterministic
+  and contained because each CI run gets its own throwaway `e2e-`-prefixed user +
+  workspace; RLS guarantees parallel runs (and real users) cannot see each other's rows.
 
-**Accepted dependency:** the PR gate depends on hosted Supabase being reachable. This is
-a controlled, highly-reliable, first-party dependency (unlike PCO/Google) and is the
-deliberate price of the fidelity requirement.
+**Accepted dependencies / risks:**
+- The PR gate depends on the hosted Supabase project being reachable — a controlled,
+  highly-reliable, first-party dependency (unlike PCO/Google).
+- The core lane creates and deletes ephemeral identities in the **same project that
+  serves production**. Blast radius is bounded by: (a) an `e2e-` naming convention on
+  every test-created user/workspace, (b) hardened, workspace-scoped teardown, and (c) a
+  stale-identity sweep at the start of each run that removes any `e2e-` leftovers a prior
+  failed teardown left behind. The `service_role` key for this project therefore lives in
+  CI secrets — this is the deliberate price of the single-project, max-fidelity choice.
 
 ---
 
@@ -256,8 +263,8 @@ incrementally toward full matrix coverage on a shared feature branch.
 | `worship@` tokens revoked/expired | Live lane fails loudly (alert), gate unaffected; document re-connect runbook. |
 | Hosted Supabase outage blocks gate | Accepted; first-party reliable dependency; retry-with-backoff on setup. |
 | Recordings drift from real APIs | Live lane re-records and PRs the diff; recordings reviewed like code. |
-| `service_role` key in CI | Stored as GitHub Secret; scoped to a dedicated test project, never prod. |
-| Ephemeral-user buildup if teardown fails | Idempotent teardown + periodic sweep of `e2e-*` users. |
+| `service_role` key in CI | Single live project; key stored as a GitHub Secret. Mitigated by `e2e-` naming + workspace-scoped teardown + start-of-run sweep. |
+| Ephemeral-user buildup / failed teardown against the live project | Start-of-run sweep deletes any `e2e-`-prefixed leftovers; teardown is idempotent and workspace-scoped. |
 | Desktop/Electron paths not covered by server-mode suite | Out of scope for v1; a thin Electron boot-smoke can be a later epic issue. |
 | PDF non-determinism | Assert structure + page count; visual-snapshot stable preview HTML, not PDF raster. |
 

--- a/docs/superpowers/specs/2026-06-05-e2e-playwright-suite-design.md
+++ b/docs/superpowers/specs/2026-06-05-e2e-playwright-suite-design.md
@@ -1,0 +1,273 @@
+# Exhaustive Playwright E2E Suite — Design
+
+**Date:** 2026-06-05
+**Status:** Approved design, pending implementation plan
+**Author:** AI pairing session with @ajhochy
+
+---
+
+## 1. Goal
+
+Build an exhaustive, durable Playwright end-to-end test suite that guards every future
+change to Bulletin Generator. It must exercise the *real* application stack — real
+`server.py`, real Supabase (auth + multitenancy + RLS), real PCO API, real Google
+Calendar, real headless-Chrome PDF generation — and cover every tab, button, field,
+modal, render path, export, and persistence flow, while remaining trustworthy enough
+to gate every pull request.
+
+Non-goal: replacing the existing `vitest` unit specs in `tests/*.spec.js`. Those remain
+the fast inner loop. This suite is the integration/E2E layer above them.
+
+---
+
+## 2. The central tension and its resolution
+
+A PR-blocking gate that depends on live third parties (PCO, Google) will go red for
+reasons unrelated to the change under test: third-party downtime, OAuth token expiry,
+rate limits, and the interactive consent screen that cannot be clicked headlessly. A
+flaky gate gets ignored — strictly worse than no gate.
+
+**Resolution: two lanes that share Page Objects, fixtures, helpers, and test bodies.**
+
+| | **Lane A — Core (PR gate)** | **Lane B — Live (real integrations)** |
+|---|---|---|
+| Backend | Real `server.py`, server mode | Real `server.py`, server mode |
+| Supabase | Real hosted test project, **ephemeral isolated user/workspace per run** | Real hosted test project, `worship@visaliacrc.com` account |
+| PCO / Google | **Recorded/replayed** real responses (deterministic) | **Live API**, read-only, using the workspace's already-connected tokens |
+| PDF | Real headless Chrome | Real headless Chrome |
+| Runs | Every push/PR, **blocking** | Nightly cron + `workflow_dispatch` + `run-live` PR label, **soft-report** |
+| Answers | "Did this change break the app?" | "Do the real integrations still work end-to-end?" |
+
+Properties:
+
+- **The Live lane is the fixture-refresh mechanism.** When Lane B runs against live
+  PCO/Google, it can re-record the HTTP exchanges that Lane A replays — so the
+  deterministic gate never drifts from reality.
+- **The interactive OAuth consent screen is never automated.** Lane B inherits the
+  `worship@` workspace's already-connected tokens; Lane A's ephemeral users have nothing
+  connected, so their PCO/Google paths are served from recordings.
+- **Isolation via the app's own multitenancy.** Both lanes hit the real hosted Supabase
+  project. Lane A stays deterministic because each CI run gets its own throwaway user +
+  workspace; RLS guarantees parallel runs cannot see each other's rows.
+
+**Accepted dependency:** the PR gate depends on hosted Supabase being reachable. This is
+a controlled, highly-reliable, first-party dependency (unlike PCO/Google) and is the
+deliberate price of the fidelity requirement.
+
+---
+
+## 3. Architecture & repository layout
+
+```
+tests/
+  unit/                      # existing vitest specs — unchanged, still the fast loop
+  e2e/
+    fixtures/                # seed JSON: projects, songs, settings, templates, announcements
+    recordings/              # captured PCO/Google HTTP (HAR) for Lane A replay
+    pages/                   # Page Object Model — one module per feature area
+      EditorPage.ts ProjectsPage.ts PcoPanel.ts CalendarPanel.ts
+      SongDbPage.ts FormatPage.ts TemplatesPage.ts SettingsPage.ts
+      AnnouncementsPanel.ts StaffPanel.ts VolunteerRolesPanel.ts
+      PreviewPane.ts AuthFlow.ts
+    flows/                   # golden-path, multi-feature journeys
+    features/                # exhaustive per-area specs (every control + route)
+    helpers/
+      server.ts              # boot real server.py in server mode, wait-for-ready, teardown
+      supabase.ts            # create/seed/delete ephemeral user + workspace (service_role)
+      auth.ts                # programmatic sign-in, storageState reuse
+      clock.ts               # page.clock helpers for debounces/heartbeat/cache
+      pdf.ts                 # validate PDF bytes + page count; snapshot print HTML
+      record-replay.ts       # PCO/Google HAR record (live) / replay (core)
+  playwright.config.ts       # two projects: "core" and "live"; shared use{} config
+```
+
+### Testing pyramid
+
+1. `vitest` unit specs (existing) — pure functions, fast.
+2. Playwright **core** — deterministic integration/E2E; the PR gate.
+3. Playwright **live** — real third-party integrations; scheduled/on-demand.
+
+---
+
+## 4. Enabling code changes (prerequisites — approved)
+
+Small, low-risk, user-invisible edits to the app source that make reliable testing
+possible:
+
+1. **Stable selectors on dynamic rows.** Add `data-testid` / `data-index` at render time
+   to every repeated row: order-of-worship items, announcements, welcome items,
+   volunteers, volunteer roles, staff, song-db items, calendar events, template cards.
+   Rationale: the survey confirmed these render without stable hooks; "click the Nth
+   row's remove button" is otherwise fragile.
+2. **Test-determinism seam.** Primary mechanism is Playwright's `page.clock` to control
+   time deterministically across the known timers:
+   - preview debounce 250ms, persist/autosave debounce 350ms
+   - presence heartbeat 30s, files auto-refresh 30s
+   - calendar cache 15min, toast dismiss 3s, designer render 300ms
+   Where `page.clock` cannot drive a behavior, a guarded `window.__E2E__` flag (set only
+   when an explicit test env var is present) shrinks the interval. The flag must be inert
+   in production builds.
+3. **No behavioral changes.** These edits add hooks only; they must not alter runtime
+   behavior for real users.
+
+---
+
+## 5. Determinism strategy
+
+- **Time:** `page.clock.install()` + `fastForward`/`runFor`; never `waitForTimeout`.
+- **PCO/Google in Lane A:** route interception serving recorded HAR; recordings live in
+  `tests/e2e/recordings/` and are refreshed by Lane B.
+- **Supabase isolation (Lane A):** per-run ephemeral user + workspace created in global
+  setup via `service_role` admin key; deleted in global teardown. Seed fixtures scoped to
+  that workspace.
+- **PDF assertion:** PDF bytes are non-reproducible. Assert `/api/pdf` → 200, valid `%PDF`
+  magic bytes, and expected page count. For visual regression, snapshot the *print-ready
+  HTML preview* (stable DOM), not the rasterized PDF.
+- **Downloads:** use Playwright's `page.waitForEvent('download')` and assert filename +
+  content type + non-empty body, rather than racing the browser's download lifecycle.
+- **Traces:** record trace/video/screenshot on failure; upload as CI artifacts.
+
+---
+
+## 6. Coverage matrix (definition of "exhaustive")
+
+Every surface below maps to at least one test, tracked to completion with a `@core` /
+`@live` tag. Source inventory: full UI + API survey performed 2026-06-05.
+
+### Navigation
+- All 6 tabs (`page-editor`, `page-files`, `page-songdb`, `page-format`,
+  `page-templates`, `page-settings`) render and switch; keyboard nav (arrows/Home/End);
+  `aria-selected` correctness.
+
+### Editor — File / Sync / Document dropdowns
+- File: bulletin title, Save, Save New Version, New, Delete, Browse, project meta,
+  presence badge.
+- Sync (PCO): connect view, service-type select, plan select, show-past toggle, Import,
+  Refresh, ignore chips add/remove, disconnect.
+- Document: service title/date, cover image upload + clear, all 8 `#opt-*` toggles,
+  booklet-size targets (auto/8/12).
+
+### Editor — content sections
+- Order of worship: add item, add page break, every item type
+  (song/liturgy/label/section/note/media), title + detail edit, per-item format override,
+  remove, **drag-reorder**, move up/down.
+- Welcome: heading, add/remove items.
+- Announcements: add/remove, title/body/url edit, page-break toggles.
+- Volunteers: rows from PCO import, name/role/time edit, remove, empty/error states.
+- Volunteer Roles: add/remove, title/body/url edit.
+- Staff: add person, name/role/email, move up/down, remove, email linking.
+- Calendar: refresh, manual add/edit/delete event, all-day toggle.
+
+### Preview pane
+- Empty state → populated; page-split correctness (section stickiness, forced breaks);
+  `.preview-linkable` click scrolls editor; page-count display.
+
+### Projects (Files tab)
+- New, import JSON, per-card open/select, bulk: select-all, export ProPresenter,
+  download JSON, download PDFs, delete-selected, clear; server-mode subtabs (My/Workspace).
+
+### Song Database
+- Add manually (title/author/lyrics/copyright), edit, delete; search; all sort options;
+  source filter; paste-from-clipboard (incl. fallback dialog); ProPresenter import
+  (disclaimer → import → preview modals); export/import JSON; clear-all.
+
+### Format
+- Page-size select; per-type formatting cards for every type; filter; save; reset;
+  verify override precedence (`getEffectiveFmt`).
+
+### Templates
+- Apply built-in (apply dialog confirm/cancel); designer overlay (open, edit element
+  formatting, name, save, save-as, export, back); import; new; font upload/list/delete.
+
+### Settings
+- Identity (server: display name); Branding (church name, give URL, logo upload/clear);
+  Google Calendar (connect/disconnect, calendar picker save/refresh, Drive folder,
+  iCal URLs save/reset, exclude titles save); Serving teams filter; Song DB export/import/
+  clear; App Updates (current version, check, banner, apply [desktop], progress).
+
+### Auth & server-mode behaviors
+- Login screen (magic link + Google sign-in); `/api/me`; logout; ownership enforcement
+  (non-owner POST → 403 → toast); read-only banner + Duplicate; 409 conflict dialog (all
+  three buttons: review, save-as-copy, replace); stale-revision poll banner; presence
+  badge with second editor; workspace members.
+
+### API routes (each hit ≥ once, status + side effect asserted)
+- `/api/bootstrap`, `/api/projects` (GET/POST/DELETE, `?id=`, `/revisions`),
+  `/api/announcements`, `/api/volunteer-roles`, `/api/settings`, `/api/songs`,
+  `/api/templates` (GET/POST/DELETE), `/api/fonts` (GET/POST/DELETE), `/api/pdf`,
+  `/api/propresenter-export`, `/api/drive/upload`, `/api/presence` (GET/POST/DELETE),
+  `/api/google-calendars`, `/pco-proxy/*`, `/cal`, `/api/admin/check-update`,
+  `/api/admin/apply-update`, `/api/me`, `/api/workspace/members`, `/auth/*`.
+
+### Golden-path flows (Lane A recorded + Lane B live)
+1. PCO import → edit items → autosave → save named version → export PDF.
+2. Build bulletin from scratch (no PCO) → all sections → export.
+3. Bulk export (JSON + PDF + ProPresenter) of multiple projects.
+4. Google Calendar connect (Lane B: pre-connected) → select calendars → events render.
+5. Conflict: two sessions → 409 → each resolution path.
+
+Each matrix row carries a tracking status so completeness is measurable, not aspirational.
+
+---
+
+## 7. CI wiring
+
+- **`.github/workflows/e2e-core.yml`** — on push/PR. Sets up Python + Node + Chromium;
+  installs Playwright browsers; provisions ephemeral Supabase user/workspace; boots
+  `server.py` in server mode; runs `@core` project. **Blocks merge.** Uploads
+  trace/video/screenshot artifacts on failure. Tears down the ephemeral identity.
+- **`.github/workflows/e2e-live.yml`** — nightly cron + `workflow_dispatch` +
+  `run-live` PR label. Reads `worship@visaliacrc.com` credentials and Supabase project
+  URL/anon/`service_role` keys from **GitHub Secrets**. Runs `@live` read-only.
+  Optionally re-records PCO/Google fixtures and opens a PR if they changed.
+  **Soft-report** by default; can be marked required on release branches.
+- **Secrets required:** Supabase project URL, anon key, `service_role` key (setup/
+  teardown), `worship@` auth credential, any PCO/Google config the server needs.
+
+### Local scripts (package.json)
+- `test:e2e` — Lane A core
+- `test:e2e:live` — Lane B live
+- `test:e2e:ui` — Playwright UI mode for debugging
+- existing `test` (`vitest run`) unchanged
+
+---
+
+## 8. Delivery sequence
+
+"Exhaustive from day one" is the target coverage, but it must be built in dependency
+order so each PR is reviewable. This is an **epic** — one issue per layer/area, landing
+incrementally toward full matrix coverage on a shared feature branch.
+
+1. **Foundation** — `playwright.config.ts`; helpers (`server`, `supabase`, `auth`,
+   `clock`, `pdf`, `record-replay`); the `data-testid` selector pass + `window.__E2E__`
+   seam. Exit: one smoke test green in both lanes.
+2. **Page Object layer** — all feature-area page objects with typed accessors.
+3. **Golden-path flows** — highest-value end-to-end journeys (§6 flows).
+4. **Exhaustive per-feature specs** — fill every remaining matrix row.
+5. **CI workflows** — core gate, then live lane + fixture auto-refresh.
+
+---
+
+## 9. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Live lane flakiness from PCO/Google | Lane B is non-blocking; only Lane A (recorded) gates PRs. |
+| `worship@` tokens revoked/expired | Live lane fails loudly (alert), gate unaffected; document re-connect runbook. |
+| Hosted Supabase outage blocks gate | Accepted; first-party reliable dependency; retry-with-backoff on setup. |
+| Recordings drift from real APIs | Live lane re-records and PRs the diff; recordings reviewed like code. |
+| `service_role` key in CI | Stored as GitHub Secret; scoped to a dedicated test project, never prod. |
+| Ephemeral-user buildup if teardown fails | Idempotent teardown + periodic sweep of `e2e-*` users. |
+| Desktop/Electron paths not covered by server-mode suite | Out of scope for v1; a thin Electron boot-smoke can be a later epic issue. |
+| PDF non-determinism | Assert structure + page count; visual-snapshot stable preview HTML, not PDF raster. |
+
+---
+
+## 10. Open items to resolve during planning
+
+- Exact mechanism for seeding an ephemeral workspace (Supabase admin API vs. app
+  bootstrap) — confirm against current `db.py` / `storage.py`.
+- Whether PCO Personal Access Token is preferable to the OAuth-stored token for any
+  Lane A fixture *recording* step.
+- TypeScript vs. plain JS for the suite (repo is ESM; Playwright supports TS out of box).
+- Desktop/Electron smoke lane: defer to a follow-up epic (noted in §9).

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,10 @@
         "electron-updater": "^6.3.9"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "autoprefixer": "^10.5.0",
         "daisyui": "^4.12.24",
+        "dotenv": "^16.6.1",
         "electron": "^28.3.3",
         "electron-builder": "^24.13.3",
         "impeccable": "github:pbakaus/impeccable",
@@ -1311,6 +1313,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@puppeteer/browsers": {
@@ -3845,13 +3863,16 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-9.0.2.tgz",
-      "integrity": "sha512-I9OvvrHp4pIARv4+x9iuewrWycX6CcZtoAu1XrzPxc5UygMJXJZYmBsynku8IkrJwgypE5DGNjDPmPRhDCptUg==",
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dotenv-expand": {
@@ -6576,13 +6597,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -6595,9 +6616,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -6996,6 +7017,16 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/read-config-file/node_modules/dotenv": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-9.0.2.tgz",
+      "integrity": "sha512-I9OvvrHp4pIARv4+x9iuewrWycX6CcZtoAu1XrzPxc5UygMJXJZYmBsynku8IkrJwgypE5DGNjDPmPRhDCptUg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/readable-stream": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,11 @@
     "css:watch": "tailwindcss -i src/css/tw-input.css -o src/css/tw-output.css --watch",
     "css:build": "tailwindcss -i src/css/tw-input.css -o src/css/tw-output.css --minify",
     "start:electron": "electron .",
-    "package:electron": "electron-builder"
+    "package:electron": "electron-builder",
+    "test:e2e": "playwright test --project=core",
+    "test:e2e:live": "playwright test --project=live",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:report": "playwright show-report"
   },
   "build": {
     "appId": "com.visaliacrc.bulletin-generator",
@@ -75,8 +79,10 @@
     }
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "autoprefixer": "^10.5.0",
     "daisyui": "^4.12.24",
+    "dotenv": "^16.6.1",
     "electron": "^28.3.3",
     "electron-builder": "^24.13.3",
     "impeccable": "github:pbakaus/impeccable",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,6 +7,10 @@ const BASE_URL = process.env.E2E_BASE_URL ?? 'http://127.0.0.1:8080';
 
 export default defineConfig({
   testDir: 'tests/e2e',
+  // *.test.ts are vitest unit tests for the helpers; Playwright must not collect
+  // them (they import 'vitest'). Playwright owns *.spec.ts only. Mirror of the
+  // vitest-side exclusion of *.spec.ts in vite.config.js.
+  testIgnore: ['**/*.test.ts'],
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,50 @@
+import { defineConfig, devices } from '@playwright/test';
+import { config as loadDotenv } from 'dotenv';
+
+loadDotenv({ path: '.env.e2e' });
+
+const BASE_URL = process.env.E2E_BASE_URL ?? 'http://127.0.0.1:8080';
+
+export default defineConfig({
+  testDir: 'tests/e2e',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: [['html', { open: 'never' }], ['list']],
+  use: {
+    baseURL: BASE_URL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  webServer: {
+    command: 'python3 server.py',
+    url: `${BASE_URL}/api/health`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+    env: {
+      APP_MODE: 'server',
+      DATABASE_URL: process.env.DATABASE_URL ?? '',
+      SUPABASE_URL: process.env.SUPABASE_URL ?? '',
+      SUPABASE_ANON_KEY: process.env.SUPABASE_ANON_KEY ?? '',
+      SUPABASE_JWT_SECRET: process.env.SUPABASE_JWT_SECRET ?? '',
+    },
+  },
+  projects: [
+    { name: 'core-setup', testMatch: /helpers\/auth\.setup\.ts/, grep: /@core-setup/, teardown: 'core-teardown' },
+    { name: 'core-teardown', testMatch: /helpers\/auth\.teardown\.ts/ },
+    { name: 'live-setup', testMatch: /helpers\/auth\.setup\.ts/, grep: /@live-setup/ },
+    {
+      name: 'core',
+      grep: /@core/,
+      dependencies: ['core-setup'],
+      use: { ...devices['Desktop Chrome'], storageState: 'tests/e2e/.auth/core.json' },
+    },
+    {
+      name: 'live',
+      grep: /@live/,
+      dependencies: ['live-setup'],
+      use: { ...devices['Desktop Chrome'], storageState: 'tests/e2e/.auth/live.json' },
+    },
+  ],
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,6 +4,9 @@ import { config as loadDotenv } from 'dotenv';
 loadDotenv({ path: '.env.e2e' });
 
 const BASE_URL = process.env.E2E_BASE_URL ?? 'http://127.0.0.1:8080';
+// server.py needs Python 3.10+ (PEP 604 unions). CI's python3 is 3.12; locally
+// set E2E_PYTHON (e.g. .venv/bin/python) if your `python3` is older.
+const PYTHON = process.env.E2E_PYTHON ?? 'python3';
 
 export default defineConfig({
   testDir: 'tests/e2e',
@@ -22,7 +25,7 @@ export default defineConfig({
     video: 'retain-on-failure',
   },
   webServer: {
-    command: 'python3 server.py',
+    command: `${PYTHON} server.py`,
     url: `${BASE_URL}/api/health`,
     reuseExistingServer: !process.env.CI,
     timeout: 60_000,

--- a/server.py
+++ b/server.py
@@ -3242,7 +3242,8 @@ class Handler(http.server.SimpleHTTPRequestHandler):
     # ── Presence endpoints ─────────────────────────────────────────────────────
 
     def _handle_post_presence_heartbeat(self):
-        """POST /api/presence/heartbeat  body: {"project_id": "<uuid>"}
+        """POST /api/presence/heartbeat  body: {"project_id": "<project-id>"}
+        project_id is the TEXT project id (proj_<ts>_<rand>), not a uuid.
         Upsert a workspace_presences row with last_seen_at = now().
         Desktop mode: no-op, returns {"ok": true}.
         """
@@ -3283,7 +3284,7 @@ class Handler(http.server.SimpleHTTPRequestHandler):
         self._send_json({"ok": True})
 
     def _handle_get_presence(self):
-        """GET /api/presence?project_id=<uuid>
+        """GET /api/presence?project_id=<project-id>
         Return active presence records for the project (last_seen_at within 90s).
         Desktop mode: returns empty list.
         """

--- a/src/js/announcements.js
+++ b/src/js/announcements.js
@@ -5,6 +5,8 @@ function annRender() {
     const card = document.createElement('div');
     card.className = 'ann-card card bg-base-100 border border-base-300 rounded-lg p-3 mb-2 shadow-sm';
     card.dataset.annIdx = idx;
+    card.dataset.testid = 'ann-row';
+    card.dataset.index = idx;
 
     // Row 1: title input + move + delete
     const row1 = document.createElement('div');
@@ -220,6 +222,8 @@ function welcomeRender() {
     const row = document.createElement('div');
     row.className = 'welcome-item-row flex items-center gap-2 mb-2';
     row.style.cssText = '';
+    row.dataset.testid = 'welcome-row';
+    row.dataset.index = idx;
 
     const input = document.createElement('input');
     input.type = 'text';

--- a/src/js/calendar.js
+++ b/src/js/calendar.js
@@ -703,6 +703,8 @@ function renderCalEventEditor() {
       const ev  = calEvents[idx];
       const row = document.createElement('div');
       row.className = 'cal-edit-row';
+      row.dataset.testid = 'cal-event-row';
+      row.dataset.index = idx;
 
       // ── Row header: time badge · title input · delete ──
       const hdr = document.createElement('div');

--- a/src/js/editor.js
+++ b/src/js/editor.js
@@ -111,6 +111,8 @@ function renderItemList() {
 
     const card = document.createElement('div');
     card.dataset.idx = idx;
+    card.dataset.testid = 'item-row';
+    card.dataset.index = idx;
 
     // ── Page-break: compact dashed divider card ──────────────────────────────
     if (item.type === 'page-break') {

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -662,6 +662,10 @@ async function restoreOnStartup() {
   }
 
   renderProjectSelect();
+  // Startup (incl. async server load + project/draft restore) is complete.
+  // Exposed so automated tests can wait for a stable state before editing,
+  // avoiding a race where the restore re-applies state over fresh edits.
+  if (typeof window !== 'undefined') window.__BG_READY__ = true;
 }
 
 let _projectsInitialized = false;

--- a/src/js/songs.js
+++ b/src/js/songs.js
@@ -217,6 +217,8 @@ function renderSongDb() {
     const realIdx = songDb.indexOf(song);
     const entry   = document.createElement('div');
     entry.className = 'song-db-entry border border-base-300 rounded-lg bg-base-100 mb-2 overflow-hidden hover:bg-base-200 cursor-pointer';
+    entry.dataset.testid = 'song-db-row';
+    entry.dataset.index = realIdx;
 
     // ── Main row (click to expand) ──
     const main = document.createElement('div');

--- a/src/js/staff.js
+++ b/src/js/staff.js
@@ -42,6 +42,8 @@ function renderStaffEditor() {
   staffData.forEach((person, idx) => {
     const row = document.createElement('div');
     row.className = 'staff-ed-row';
+    row.dataset.testid = 'staff-row';
+    row.dataset.index = idx;
 
     const nameIn  = document.createElement('input');
     const roleIn  = document.createElement('input');

--- a/src/js/volunteer-roles.js
+++ b/src/js/volunteer-roles.js
@@ -6,6 +6,8 @@ function vrRender() {
     const card = document.createElement('div');
     card.className = 'vr-card card bg-base-100 border border-base-300 rounded-lg p-3 mb-2 shadow-sm';
     card.dataset.vrIdx = idx;
+    card.dataset.testid = 'vr-row';
+    card.dataset.index = idx;
 
     // Row 1: title input + move + delete
     const row1 = document.createElement('div');

--- a/supabase/migrations/20260605000001_grant_service_role_dml.sql
+++ b/supabase/migrations/20260605000001_grant_service_role_dml.sql
@@ -1,0 +1,18 @@
+-- Restore Supabase's default service_role privileges on the public schema.
+--
+-- This project's tenancy migrations granted DML to `authenticated` and revoked
+-- `anon`, but never granted to `service_role`. On a default Supabase scaffold,
+-- service_role automatically receives full DML across the public schema; that
+-- default was omitted here. The E2E core lane provisions/destroys isolated
+-- `e2e-` test identities via the service_role key and therefore needs it.
+--
+-- service_role already bypasses RLS and is a server-only master key, so these
+-- grants do not widen the project's exposure beyond Supabase's defaults.
+
+GRANT ALL ON ALL TABLES IN SCHEMA public TO service_role;
+GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO service_role;
+GRANT ALL ON ALL FUNCTIONS IN SCHEMA public TO service_role;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO service_role;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO service_role;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO service_role;

--- a/supabase/migrations/20260605000002_presence_project_id_text.sql
+++ b/supabase/migrations/20260605000002_presence_project_id_text.sql
@@ -1,0 +1,31 @@
+-- Migration: presence_project_id_text
+-- Fix: workspace_presences.project_id was created as uuid (see
+-- 20260603000003_workspace_presences.sql), but public.projects.id is TEXT in the
+-- format proj_<timestamp>_<rand> (e.g. proj_1780694817495_5s3vrh). Binding a TEXT
+-- project id against the uuid column made Postgres raise
+-- psycopg.errors.InvalidTextRepresentation ("invalid input syntax for type uuid"),
+-- 500-ing every presence GET (_handle_get_presence) and heartbeat upsert
+-- (_handle_post_presence_heartbeat) for real projects. The frontend swallows
+-- presence errors (best-effort), so it was silently broken for all projects.
+--
+-- Align the column type with public.projects.id (TEXT). uuid -> text is a
+-- widening cast (every uuid has a text representation), so existing rows convert
+-- losslessly. The primary key (workspace_id, user_id, project_id) and the
+-- workspace_presences_workspace_project_idx index are rebuilt automatically.
+--
+-- Idempotent: only alters when the column is still uuid.
+
+do $$
+begin
+  if exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name   = 'workspace_presences'
+      and column_name  = 'project_id'
+      and data_type    = 'uuid'
+  ) then
+    alter table public.workspace_presences
+      alter column project_id type text using project_id::text;
+  end if;
+end $$;

--- a/tests/e2e/features/announcements.spec.ts
+++ b/tests/e2e/features/announcements.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+import { AppShell } from '../pages/AppShell';
+import { expandSection, row } from '../pages/common';
+
+test.describe('@core Announcements', () => {
+  test('add, edit, and remove announcements', async ({ page }) => {
+    const shell = new AppShell(page);
+    await shell.goto();
+    await shell.expectAuthenticated();
+    await shell.switchTo('editor');
+    await expandSection(page, 'Announcements');
+
+    const rows = page.locator('[data-testid="ann-row"]');
+    const addBtn = page.locator('#ann-add-btn');
+
+    // Add the first announcement; it persists via POST /api/announcements.
+    const saved = page.waitForResponse(
+      (r) => r.url().includes('/api/announcements') && r.request().method() === 'POST' && r.ok(),
+      { timeout: 15_000 },
+    );
+    await addBtn.click();
+    await saved;
+    await expect(rows).toHaveCount(1);
+
+    // Edit its title.
+    await row(page, 'ann', 0).locator('.ann-title-input').fill('E2E Announcement');
+    await expect(row(page, 'ann', 0).locator('.ann-title-input')).toHaveValue('E2E Announcement');
+
+    // Add a second, then remove the first (no confirm on announcement delete).
+    await addBtn.click();
+    await expect(rows).toHaveCount(2);
+    await row(page, 'ann', 0).getByTitle('Remove').click();
+    await expect(rows).toHaveCount(1);
+  });
+});

--- a/tests/e2e/features/editor-order-of-worship.spec.ts
+++ b/tests/e2e/features/editor-order-of-worship.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test';
+import { AppShell } from '../pages/AppShell';
+import { EditorPage } from '../pages/EditorPage';
+import { createAndSaveProject } from '../pages/common';
+
+test.describe('@core Order of Worship editing', () => {
+  test('add items, set type/title, reorder, page break, delete — reflected in preview', async ({ page }) => {
+    const shell = new AppShell(page);
+    await shell.goto();
+    await shell.expectAuthenticated();
+    await createAndSaveProject(page, 'E2E OOW');
+
+    const editor = new EditorPage(page);
+    await editor.openOrderOfWorship();
+
+    // Add a section heading. Editor state is the stable signal; the section
+    // also renders in the live preview (the preview re-renders constantly as the
+    // calendar loads, so we only assert the always-rendered section heading there).
+    await editor.addItem();
+    await editor.setType(0, 'section');
+    await editor.setTitle(0, 'GATHERING');
+    await expect(editor.item(0).locator('.item-title-input')).toHaveValue('GATHERING');
+    await expect(editor.preview()).toContainText('GATHERING', { timeout: 10_000 });
+
+    // Add a song (title-only songs don't render in the preview; assert state).
+    await editor.addItem();
+    await editor.setType(1, 'song');
+    await editor.setTitle(1, 'Amazing Grace');
+    await expect(editor.item(1).locator('.item-title-input')).toHaveValue('Amazing Grace');
+    await expect(editor.items()).toHaveCount(2);
+
+    // Reorder: move the song above the section heading.
+    await editor.moveUp(1);
+    await expect(editor.item(0).locator('.item-title-input')).toHaveValue('Amazing Grace');
+    await expect(editor.item(1).locator('.item-title-input')).toHaveValue('GATHERING');
+
+    // Insert a page break, then delete it.
+    await editor.addPageBreak();
+    await expect(editor.items()).toHaveCount(3);
+    await editor.deleteItem(2);
+    await expect(editor.items()).toHaveCount(2);
+
+    // Delete the song; the section heading remains.
+    await editor.deleteItem(0);
+    await expect(editor.items()).toHaveCount(1);
+    await expect(editor.item(0).locator('.item-title-input')).toHaveValue('GATHERING');
+  });
+});

--- a/tests/e2e/features/editor-sections.spec.ts
+++ b/tests/e2e/features/editor-sections.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test';
+import { AppShell } from '../pages/AppShell';
+import { expandSection, row } from '../pages/common';
+
+/** Add a row, edit a field, remove it — asserting relative to the current count
+ *  (these sections may be pre-seeded with workspace defaults). */
+async function addEditRemove(opts: {
+  page: import('@playwright/test').Page;
+  sectionLabel: string;
+  addBtn: string;
+  area: string;
+  fieldSelector: string;
+  value: string;
+}): Promise<void> {
+  const { page, sectionLabel, addBtn, area, fieldSelector, value } = opts;
+  await expandSection(page, sectionLabel);
+  const rows = page.locator(`[data-testid="${area}-row"]`);
+  const before = await rows.count();
+
+  await page.locator(addBtn).click();
+  await expect(rows).toHaveCount(before + 1);
+
+  await row(page, area, before).locator(fieldSelector).first().fill(value);
+  await expect(row(page, area, before).locator(fieldSelector).first()).toHaveValue(value);
+
+  await row(page, area, before).getByTitle('Remove').click();
+  await expect(rows).toHaveCount(before);
+}
+
+test.describe('@core Editor sidebar sections', () => {
+  test.beforeEach(async ({ page }) => {
+    const shell = new AppShell(page);
+    await shell.goto();
+    await shell.expectAuthenticated();
+    await shell.switchTo('editor');
+  });
+
+  test('Welcome: add, edit, remove', async ({ page }) => {
+    await addEditRemove({
+      page, sectionLabel: 'Welcome', addBtn: '#welcome-add-btn',
+      area: 'welcome', fieldSelector: '.ann-title-input', value: 'E2E Welcome Item',
+    });
+  });
+
+  test('Volunteer Roles: add, edit, remove', async ({ page }) => {
+    await addEditRemove({
+      page, sectionLabel: 'Volunteer Roles', addBtn: '#vr-add-btn',
+      area: 'vr', fieldSelector: '.vr-title-input', value: 'E2E Role',
+    });
+  });
+
+  test('Staff: add, edit, remove', async ({ page }) => {
+    await addEditRemove({
+      page, sectionLabel: 'Church Staff', addBtn: '#staff-add-btn',
+      area: 'staff', fieldSelector: '.staff-ed-input', value: 'E2E Person',
+    });
+  });
+});

--- a/tests/e2e/features/format.spec.ts
+++ b/tests/e2e/features/format.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+import { AppShell } from '../pages/AppShell';
+import { waitForAppReady } from '../pages/common';
+
+test.describe('@core Format', () => {
+  test('document page size changes and persists across reload', async ({ page }) => {
+    const shell = new AppShell(page);
+    await shell.goto();
+    await shell.expectAuthenticated();
+    await shell.switchTo('format');
+
+    const sel = page.locator('#doc-page-size-sel');
+    await expect(sel).toBeVisible();
+
+    // Changing page size POSTs /api/settings { docTemplate } immediately.
+    const saved = page.waitForResponse(
+      (r) => r.url().includes('/api/settings') && r.request().method() === 'POST' && r.ok(),
+      { timeout: 15_000 },
+    );
+    await sel.selectOption('8.5x11');
+    await saved;
+    await expect(sel).toHaveValue('8.5x11');
+
+    // Persisted: survives a reload.
+    await page.reload();
+    await waitForAppReady(page);
+    await shell.switchTo('format');
+    await expect(page.locator('#doc-page-size-sel')).toHaveValue('8.5x11');
+  });
+});

--- a/tests/e2e/features/projects.spec.ts
+++ b/tests/e2e/features/projects.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+import { AppShell } from '../pages/AppShell';
+import { ProjectsPage } from '../pages/ProjectsPage';
+import { createAndSaveProject, openToolbarMenu } from '../pages/common';
+
+test.describe('@core Projects (Files)', () => {
+  test('create, list, open, select, and delete projects', async ({ page }) => {
+    page.on('dialog', (d) => d.accept()); // New / Delete use native confirm()
+
+    const shell = new AppShell(page);
+    await shell.goto();
+    await shell.expectAuthenticated();
+    const projects = new ProjectsPage(page);
+
+    // Create project Alpha.
+    await shell.switchTo('editor');
+    await createAndSaveProject(page, 'E2E Project Alpha');
+
+    // Start a New project, then save it as Beta (saving the active project would
+    // rename it, so New resets the active project first).
+    await openToolbarMenu(page, 'file');
+    await page.locator('#project-new-btn').click();
+    await createAndSaveProject(page, 'E2E Project Beta');
+
+    // Both appear in the Projects list.
+    await shell.switchTo('files');
+    await expect(projects.cardByName('E2E Project Alpha')).toBeVisible();
+    await expect(projects.cardByName('E2E Project Beta')).toBeVisible();
+
+    // Open Alpha → the editor loads it (bulletin title reflects the name).
+    await projects.loadByName('E2E Project Alpha');
+    await shell.switchTo('editor');
+    await openToolbarMenu(page, 'file');
+    await expect(page.locator('#bulletin-title')).toHaveValue('E2E Project Alpha');
+
+    // Selecting a card surfaces the bulk-actions bar.
+    await shell.switchTo('files');
+    await projects.toggleSelect('E2E Project Alpha');
+    await expect(projects.bulkBar()).toHaveClass(/visible/);
+
+    // Delete Beta; Alpha remains.
+    await projects.deleteByName('E2E Project Beta');
+    await expect(projects.cardByName('E2E Project Alpha')).toBeVisible();
+  });
+});

--- a/tests/e2e/features/server-mode-behaviors.spec.ts
+++ b/tests/e2e/features/server-mode-behaviors.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+import { AppShell } from '../pages/AppShell';
+import { ProjectsPage } from '../pages/ProjectsPage';
+import { createAndSaveProject, waitForAppReady } from '../pages/common';
+import { signInAs } from '../helpers/session';
+import {
+  createWorkspaceMember,
+  removeWorkspaceMember,
+  type EphemeralIdentity,
+} from '../helpers/supabase-admin';
+
+test.describe('@core Server-mode multitenant behaviors', () => {
+  test('a non-owner member sees another member\'s workspace project as read-only', async ({ page, browser }) => {
+    // User A = the core ephemeral owner (default storageState). Create a project
+    // (new projects default to visibility='workspace', so other members see it).
+    const shellA = new AppShell(page);
+    await shellA.goto();
+    await shellA.expectAuthenticated();
+    await shellA.switchTo('editor');
+    await createAndSaveProject(page, 'E2E Shared Bulletin');
+
+    // Add a disposable second member (User B) to A's workspace.
+    const a = JSON.parse(readFileSync('tests/e2e/.auth/core-ids.json', 'utf8')) as EphemeralIdentity;
+    let b: EphemeralIdentity | null = null;
+    try {
+      b = await createWorkspaceMember(a.workspaceId, 'editor');
+
+      // Drive User B in a separate browser context.
+      const ctxB = await browser.newContext();
+      const pageB = await ctxB.newPage();
+      await signInAs(pageB, b.email, b.password);
+
+      const shellB = new AppShell(pageB);
+      await shellB.switchTo('files');
+      await new ProjectsPage(pageB).loadByName('E2E Shared Bulletin');
+      await shellB.switchTo('editor');
+
+      // B is not the owner → read-only banner appears.
+      await expect(pageB.locator('#readonly-banner')).toBeVisible({ timeout: 15_000 });
+
+      await ctxB.close();
+    } finally {
+      if (b) await removeWorkspaceMember(b);
+    }
+  });
+});

--- a/tests/e2e/features/settings-branding.spec.ts
+++ b/tests/e2e/features/settings-branding.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+import { AppShell } from '../pages/AppShell';
+import { waitForAppReady } from '../pages/common';
+
+test.describe('@core Settings — branding', () => {
+  test('church name and give-online URL persist across reload', async ({ page }) => {
+    const shell = new AppShell(page);
+    await shell.goto();
+    await shell.expectAuthenticated();
+    await shell.switchTo('settings');
+
+    // Each field POSTs to /api/settings on input.
+    const churchSaved = page.waitForResponse(
+      (r) => r.url().includes('/api/settings') && r.request().method() === 'POST' && r.ok(),
+      { timeout: 15_000 },
+    );
+    await page.locator('#svc-church').fill('E2E Test Church');
+    await churchSaved;
+
+    const giveSaved = page.waitForResponse(
+      (r) => r.url().includes('/api/settings') && r.request().method() === 'POST' && r.ok(),
+      { timeout: 15_000 },
+    );
+    await page.locator('#give-online-url-input').fill('https://example.org/give');
+    await giveSaved;
+
+    // Reload and confirm the server-persisted values are restored.
+    await page.reload();
+    await waitForAppReady(page);
+    await shell.switchTo('settings');
+    await expect(page.locator('#svc-church')).toHaveValue('E2E Test Church');
+    await expect(page.locator('#give-online-url-input')).toHaveValue('https://example.org/give');
+  });
+});

--- a/tests/e2e/features/song-database.spec.ts
+++ b/tests/e2e/features/song-database.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+import { AppShell } from '../pages/AppShell';
+import { SongDbPage } from '../pages/SongDbPage';
+
+test.describe('@core Song Database', () => {
+  test('add songs, search/filter, and delete', async ({ page }) => {
+    page.on('dialog', (d) => d.accept()); // delete uses native confirm()
+
+    const shell = new AppShell(page);
+    await shell.goto();
+    await shell.expectAuthenticated();
+    await shell.switchTo('songdb');
+
+    const songs = new SongDbPage(page);
+
+    await songs.add('E2E Hymn One', 'Author Alpha', 'Verse one lyrics', 'CCLI 1111');
+    await expect(songs.rowByTitle('E2E Hymn One')).toBeVisible();
+
+    await songs.add('E2E Hymn Two', 'Author Beta', 'Verse two lyrics', 'CCLI 2222');
+    await expect(songs.rowByTitle('E2E Hymn Two')).toBeVisible();
+
+    // Search narrows the list to the matching song.
+    await songs.search().fill('Hymn One');
+    await expect(songs.rowByTitle('E2E Hymn One')).toBeVisible();
+    await expect(songs.rowByTitle('E2E Hymn Two')).toHaveCount(0);
+    await songs.search().fill('');
+    await expect(songs.rowByTitle('E2E Hymn Two')).toBeVisible();
+
+    // Delete one; the other remains.
+    await songs.deleteByTitle('E2E Hymn One');
+    await expect(songs.rowByTitle('E2E Hymn Two')).toBeVisible();
+  });
+});

--- a/tests/e2e/features/templates.spec.ts
+++ b/tests/e2e/features/templates.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+import { AppShell } from '../pages/AppShell';
+
+test.describe('@core Templates', () => {
+  test('gallery renders and the designer overlay opens and closes', async ({ page }) => {
+    page.on('dialog', (d) => d.accept()); // Back on an unsaved designer prompts discard
+
+    const shell = new AppShell(page);
+    await shell.goto();
+    await shell.expectAuthenticated();
+    await shell.switchTo('templates');
+
+    // The gallery shows at least the built-in templates.
+    await expect(page.locator('#tpl-grid .tpl-template-card').first()).toBeVisible();
+
+    // "New Template" first opens a base-template picker modal; Create proceeds
+    // into the full-screen designer overlay.
+    const overlay = page.locator('#tpl-designer-overlay');
+    await page.locator('#tpl-new-btn').click();
+    await page.getByRole('button', { name: 'Create', exact: true }).click();
+    await expect(overlay).toBeVisible();
+
+    // Back closes it.
+    await page.locator('#tpl-designer-back').click();
+    await expect(overlay).toBeHidden();
+  });
+});

--- a/tests/e2e/flows/build-bulletin.spec.ts
+++ b/tests/e2e/flows/build-bulletin.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+import { AppShell } from '../pages/AppShell';
+import { EditorPage } from '../pages/EditorPage';
+import { createAndSaveProject, expandSection, row } from '../pages/common';
+import { assertValidPdf } from '../helpers/pdf';
+
+test.describe('@core Golden flow — build a bulletin from scratch', () => {
+  test('create → add order of worship + announcement → set page size → export PDF', async ({ page }) => {
+    const shell = new AppShell(page);
+    await shell.goto();
+    await shell.expectAuthenticated();
+
+    // 1. Create + persist a named project.
+    await shell.switchTo('editor');
+    await createAndSaveProject(page, 'E2E Golden Bulletin');
+
+    // 2. Build the order of worship (section heading + song).
+    const editor = new EditorPage(page);
+    await editor.openOrderOfWorship();
+    await editor.addItem();
+    await editor.setType(0, 'section');
+    await editor.setTitle(0, 'GATHERING');
+    await editor.addItem();
+    await editor.setType(1, 'song');
+    await editor.setTitle(1, 'How Great Thou Art');
+    await expect(editor.items()).toHaveCount(2);
+
+    // 3. Add an announcement.
+    await expandSection(page, 'Announcements');
+    await page.locator('#ann-add-btn').click();
+    await row(page, 'ann', 0).locator('.ann-title-input').fill('Potluck Sunday');
+    await expect(row(page, 'ann', 0).locator('.ann-title-input')).toHaveValue('Potluck Sunday');
+
+    // 4. Choose a page size in the Format tab.
+    await shell.switchTo('format');
+    await page.locator('#doc-page-size-sel').selectOption('8.5x11');
+    await expect(page.locator('#doc-page-size-sel')).toHaveValue('8.5x11');
+
+    // 5. Export a print-ready PDF and assert the bytes are a valid PDF.
+    await shell.switchTo('editor');
+    const printBtn = page.locator('#btn-print');
+    await expect(printBtn).toBeEnabled();
+    const downloadPromise = page.waitForEvent('download');
+    await printBtn.click();
+    const download = await downloadPromise;
+    const filePath = await download.path();
+    expect(filePath).toBeTruthy();
+    assertValidPdf(readFileSync(filePath!));
+  });
+});

--- a/tests/e2e/flows/smoke.spec.ts
+++ b/tests/e2e/flows/smoke.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { readFileSync } from 'node:fs';
 import { AppShell } from '../pages/AppShell';
+import { createAndSaveProject, openToolbarMenu } from '../pages/common';
 import { assertValidPdf } from '../helpers/pdf';
 
 test.describe('@core harness smoke', () => {
@@ -14,18 +15,11 @@ test.describe('@core harness smoke', () => {
     }
 
     // Create + persist a project, proving the full frontend -> server.py ->
-    // Supabase write path. Autosave only fires once a project is active
-    // (projects.js:345), so a fresh user must explicitly Save first: open the
-    // File menu (a <details>), name the bulletin, click Save, await the POST.
+    // Supabase write path. (createAndSaveProject opens the File menu, names the
+    // bulletin, Saves, and awaits the POST — the canonical persistable-project
+    // flow, since autosave only fires once a project is active.)
     await shell.switchTo('editor');
-    await page.locator('#editor-toolbar-file summary').click();
-    await page.locator('#bulletin-title').fill('E2E Smoke Bulletin');
-    const saved = page.waitForResponse(
-      (r) => r.url().includes('/api/projects') && r.request().method() === 'POST' && r.ok(),
-      { timeout: 15_000 },
-    );
-    await page.locator('#project-save-btn').click();
-    await saved;
+    await createAndSaveProject(page, 'E2E Smoke Bulletin');
 
     // Confirm it persisted: the saved project appears in the Projects list.
     await shell.switchTo('files');
@@ -52,7 +46,7 @@ test.describe('@live real-integration smoke', () => {
     await shell.expectAuthenticated();
     // PCO connected (inherited from worship@'s workspace) → the import view
     // (hidden until connected) is visible. Read-only: we never trigger an import.
-    await page.locator('#editor-toolbar-sync summary').click();
+    await openToolbarMenu(page, 'sync');
     await expect(page.locator('#pco-import-view')).toBeVisible();
   });
 });

--- a/tests/e2e/flows/smoke.spec.ts
+++ b/tests/e2e/flows/smoke.spec.ts
@@ -1,12 +1,10 @@
 import { test, expect } from '@playwright/test';
 import { readFileSync } from 'node:fs';
 import { AppShell } from '../pages/AppShell';
-import { installClock, settlePersist } from '../helpers/clock';
 import { assertValidPdf } from '../helpers/pdf';
 
 test.describe('@core harness smoke', () => {
   test('boots, authenticates, navigates, persists a project, exports PDF', async ({ page }) => {
-    await installClock(page);
     const shell = new AppShell(page);
     await shell.goto();
     await shell.expectAuthenticated();
@@ -15,18 +13,23 @@ test.describe('@core harness smoke', () => {
       await shell.switchTo(tab);
     }
 
-    // Create + persist a project via the UI.
+    // Create + persist a project, proving the full frontend -> server.py ->
+    // Supabase write path. Autosave only fires once a project is active
+    // (projects.js:345), so a fresh user must explicitly Save first: open the
+    // File menu (a <details>), name the bulletin, click Save, await the POST.
     await shell.switchTo('editor');
+    await page.locator('#editor-toolbar-file summary').click();
     await page.locator('#bulletin-title').fill('E2E Smoke Bulletin');
-    await page.locator('#svc-title').fill('Smoke Service');
-    await page.locator('#add-item-btn').click();
-    await page.locator('[data-testid="item-row"][data-index="0"] .item-title-input').fill('Welcome');
-    await settlePersist(page);
+    const saved = page.waitForResponse(
+      (r) => r.url().includes('/api/projects') && r.request().method() === 'POST' && r.ok(),
+      { timeout: 15_000 },
+    );
+    await page.locator('#project-save-btn').click();
+    await saved;
 
-    // Confirm it persisted by reloading and finding it in Files.
-    await page.reload();
+    // Confirm it persisted: the saved project appears in the Projects list.
     await shell.switchTo('files');
-    await expect(page.locator('#files-list')).toContainText('E2E Smoke Bulletin');
+    await expect(page.locator('#files-list')).toContainText('E2E Smoke Bulletin', { timeout: 10_000 });
 
     // Export a PDF through the real UI button (authenticated, via app JS) and
     // assert the downloaded bytes are a valid PDF.
@@ -49,7 +52,7 @@ test.describe('@live real-integration smoke', () => {
     await shell.expectAuthenticated();
     // PCO connected (inherited from worship@'s workspace) → the import view
     // (hidden until connected) is visible. Read-only: we never trigger an import.
-    await page.locator('#editor-toolbar-sync').click();
+    await page.locator('#editor-toolbar-sync summary').click();
     await expect(page.locator('#pco-import-view')).toBeVisible();
   });
 });

--- a/tests/e2e/flows/smoke.spec.ts
+++ b/tests/e2e/flows/smoke.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+import { AppShell } from '../pages/AppShell';
+import { installClock, settlePersist } from '../helpers/clock';
+import { assertValidPdf } from '../helpers/pdf';
+
+test.describe('@core harness smoke', () => {
+  test('boots, authenticates, navigates, persists a project, exports PDF', async ({ page }) => {
+    await installClock(page);
+    const shell = new AppShell(page);
+    await shell.goto();
+    await shell.expectAuthenticated();
+
+    for (const tab of ['files', 'songdb', 'format', 'templates', 'settings', 'editor'] as const) {
+      await shell.switchTo(tab);
+    }
+
+    // Create + persist a project via the UI.
+    await shell.switchTo('editor');
+    await page.locator('#bulletin-title').fill('E2E Smoke Bulletin');
+    await page.locator('#svc-title').fill('Smoke Service');
+    await page.locator('#add-item-btn').click();
+    await page.locator('[data-testid="item-row"][data-index="0"] .item-title-input').fill('Welcome');
+    await settlePersist(page);
+
+    // Confirm it persisted by reloading and finding it in Files.
+    await page.reload();
+    await shell.switchTo('files');
+    await expect(page.locator('#files-list')).toContainText('E2E Smoke Bulletin');
+
+    // Export a PDF through the real UI button (authenticated, via app JS) and
+    // assert the downloaded bytes are a valid PDF.
+    await shell.switchTo('editor');
+    const printBtn = page.locator('#btn-print');
+    await expect(printBtn).toBeEnabled();
+    const downloadPromise = page.waitForEvent('download');
+    await printBtn.click();
+    const download = await downloadPromise;
+    const filePath = await download.path();
+    expect(filePath).toBeTruthy();
+    assertValidPdf(readFileSync(filePath!));
+  });
+});
+
+test.describe('@live real-integration smoke', () => {
+  test('e2e-live member is authenticated and PCO is connected', async ({ page }) => {
+    const shell = new AppShell(page);
+    await shell.goto();
+    await shell.expectAuthenticated();
+    // PCO connected (inherited from worship@'s workspace) → the import view
+    // (hidden until connected) is visible. Read-only: we never trigger an import.
+    await page.locator('#editor-toolbar-sync').click();
+    await expect(page.locator('#pco-import-view')).toBeVisible();
+  });
+});

--- a/tests/e2e/helpers/auth.setup.ts
+++ b/tests/e2e/helpers/auth.setup.ts
@@ -1,0 +1,70 @@
+import { test as setup, expect, type Page } from '@playwright/test';
+import { createClient } from '@supabase/supabase-js';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { e2eEnv } from './env';
+import {
+  createEphemeralIdentity,
+  sweepStaleEphemeralIdentities,
+  ensureLiveWorkspaceMember,
+} from './supabase-admin';
+
+const AUTH_DIR = 'tests/e2e/.auth';
+const CORE_STATE = `${AUTH_DIR}/core.json`;
+const LIVE_STATE = `${AUTH_DIR}/live.json`;
+const CORE_IDS = `${AUTH_DIR}/core-ids.json`;
+
+/** The Supabase project ref is the first hostname label of SUPABASE_URL. */
+function projectRef(url: string): string {
+  return new URL(url).hostname.split('.')[0];
+}
+
+/**
+ * The app's login UI offers no password field (Google / magic-link only), so we
+ * sign in programmatically with the password we control, then inject the
+ * resulting session into the page's localStorage under the supabase-js v2 key
+ * (`sb-<ref>-auth-token`). On reload the app's supabase client picks it up. The
+ * `#user-info` assertion is a self-check: if the injected session shape is ever
+ * wrong, setup fails loudly here instead of producing a silently-unauthed state.
+ */
+async function signInAndSave(page: Page, email: string, password: string, statePath: string): Promise<void> {
+  const env = e2eEnv(['SUPABASE_URL', 'SUPABASE_ANON_KEY'] as const);
+  const node = createClient(env.SUPABASE_URL, env.SUPABASE_ANON_KEY, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  const { data, error } = await node.auth.signInWithPassword({ email, password });
+  if (error || !data.session) {
+    throw new Error(`signInWithPassword failed for ${email}: ${error?.message}`);
+  }
+  const storageKey = `sb-${projectRef(env.SUPABASE_URL)}-auth-token`;
+  const sessionJson = JSON.stringify(data.session);
+
+  await page.goto('/');
+  await page.evaluate(
+    (args: { key: string; value: string }) => window.localStorage.setItem(args.key, args.value),
+    { key: storageKey, value: sessionJson },
+  );
+  await page.reload();
+  await expect(page.locator('#user-info')).toBeVisible({ timeout: 15_000 });
+
+  mkdirSync(AUTH_DIR, { recursive: true });
+  await page.context().storageState({ path: statePath });
+}
+
+setup('@core-setup provision ephemeral identity', async ({ page }) => {
+  await sweepStaleEphemeralIdentities(); // remove any leftovers from a prior failed run
+  const id = await createEphemeralIdentity('core');
+  mkdirSync(AUTH_DIR, { recursive: true });
+  writeFileSync(CORE_IDS, JSON.stringify(id));
+  await signInAndSave(page, id.email, id.password, CORE_STATE);
+});
+
+setup('@live-setup ensure e2e-live member + sign in', async ({ page }) => {
+  const env = e2eEnv(['E2E_LIVE_EMAIL', 'E2E_LIVE_PASSWORD'] as const);
+  // worship@'s workspace holds the already-connected PCO/Google tokens.
+  await ensureLiveWorkspaceMember({
+    liveEmail: env.E2E_LIVE_EMAIL,
+    livePassword: env.E2E_LIVE_PASSWORD,
+    ownerEmail: 'worship@visaliacrc.com',
+  });
+  await signInAndSave(page, env.E2E_LIVE_EMAIL, env.E2E_LIVE_PASSWORD, LIVE_STATE);
+});

--- a/tests/e2e/helpers/auth.setup.ts
+++ b/tests/e2e/helpers/auth.setup.ts
@@ -36,6 +36,9 @@ async function signInAndSave(page: Page, email: string, password: string, stateP
     throw new Error(`signInWithPassword failed for ${email}: ${error?.message}`);
   }
   const storageKey = `sb-${projectRef(env.SUPABASE_URL)}-auth-token`;
+  // Correct for @supabase/supabase-js v2 with default storage. ASSUMES the app
+  // client (src/js/auth-ui.js) is NOT configured with `userStorage`; if that is
+  // ever enabled, the session must be split into `<key>` (no user) + `<key>-user`.
   const sessionJson = JSON.stringify(data.session);
 
   await page.goto('/');

--- a/tests/e2e/helpers/auth.teardown.ts
+++ b/tests/e2e/helpers/auth.teardown.ts
@@ -1,0 +1,12 @@
+import { test as teardown } from '@playwright/test';
+import { readFileSync, existsSync, rmSync } from 'node:fs';
+import { destroyEphemeralIdentity, type EphemeralIdentity } from './supabase-admin';
+
+const CORE_IDS = 'tests/e2e/.auth/core-ids.json';
+
+teardown('destroy ephemeral identity', async () => {
+  if (!existsSync(CORE_IDS)) return;
+  const id = JSON.parse(readFileSync(CORE_IDS, 'utf8')) as EphemeralIdentity;
+  await destroyEphemeralIdentity(id);
+  rmSync(CORE_IDS, { force: true });
+});

--- a/tests/e2e/helpers/clock.ts
+++ b/tests/e2e/helpers/clock.ts
@@ -1,0 +1,25 @@
+import type { Page } from '@playwright/test';
+
+/** App debounce/timer constants (verified in src/js). */
+export const TIMERS = {
+  previewDebounceMs: 250,
+  persistDebounceMs: 350,
+  presenceHeartbeatMs: 30_000,
+  filesRefreshMs: 30_000,
+  calCacheMs: 15 * 60 * 1000,
+} as const;
+
+/** Install a controllable clock. Call before navigation. */
+export async function installClock(page: Page): Promise<void> {
+  await page.clock.install();
+}
+
+/** Advance past the autosave debounce so a persist POST fires deterministically. */
+export async function settlePersist(page: Page): Promise<void> {
+  await page.clock.runFor(TIMERS.previewDebounceMs + TIMERS.persistDebounceMs + 50);
+}
+
+/** Advance one presence heartbeat interval. */
+export async function tickPresence(page: Page): Promise<void> {
+  await page.clock.runFor(TIMERS.presenceHeartbeatMs + 100);
+}

--- a/tests/e2e/helpers/env.test.ts
+++ b/tests/e2e/helpers/env.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { loadE2eEnv } from './env';
+
+describe('loadE2eEnv', () => {
+  it('throws a clear error when a required var is missing', () => {
+    expect(() => loadE2eEnv({}, ['SUPABASE_URL'])).toThrow(/SUPABASE_URL/);
+  });
+  it('returns the requested vars when present', () => {
+    const env = loadE2eEnv({ SUPABASE_URL: 'x', SUPABASE_ANON_KEY: 'y' }, [
+      'SUPABASE_URL',
+      'SUPABASE_ANON_KEY',
+    ]);
+    expect(env).toEqual({ SUPABASE_URL: 'x', SUPABASE_ANON_KEY: 'y' });
+  });
+});

--- a/tests/e2e/helpers/env.ts
+++ b/tests/e2e/helpers/env.ts
@@ -1,0 +1,31 @@
+import { config as loadDotenv } from 'dotenv';
+
+let loaded = false;
+function ensureDotenv() {
+  if (!loaded) {
+    loadDotenv({ path: '.env.e2e' });
+    loaded = true;
+  }
+}
+
+export function loadE2eEnv<K extends string>(
+  source: Record<string, string | undefined>,
+  required: readonly K[],
+): Record<K, string> {
+  const out = {} as Record<K, string>;
+  const missing: string[] = [];
+  for (const key of required) {
+    const val = source[key];
+    if (!val) missing.push(key);
+    else out[key] = val;
+  }
+  if (missing.length) {
+    throw new Error(`Missing required E2E env var(s): ${missing.join(', ')}`);
+  }
+  return out;
+}
+
+export function e2eEnv<K extends string>(required: readonly K[]): Record<K, string> {
+  ensureDotenv();
+  return loadE2eEnv(process.env, required);
+}

--- a/tests/e2e/helpers/pdf.test.ts
+++ b/tests/e2e/helpers/pdf.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { assertValidPdf } from './pdf';
+
+describe('assertValidPdf', () => {
+  it('accepts a minimal PDF buffer', () => {
+    const buf = Buffer.from('%PDF-1.4\n1 0 obj<<>>endobj\n%%EOF');
+    expect(() => assertValidPdf(buf)).not.toThrow();
+  });
+  it('rejects non-PDF bytes', () => {
+    expect(() => assertValidPdf(Buffer.from('<html></html>'))).toThrow(/not a PDF/i);
+  });
+  it('rejects an empty buffer', () => {
+    expect(() => assertValidPdf(Buffer.alloc(0))).toThrow(/empty/i);
+  });
+});

--- a/tests/e2e/helpers/pdf.ts
+++ b/tests/e2e/helpers/pdf.ts
@@ -1,0 +1,10 @@
+/** Throws unless `buf` looks like a valid, non-empty PDF. Returns the page count (best-effort). */
+export function assertValidPdf(buf: Buffer): number {
+  if (!buf || buf.length === 0) throw new Error('PDF buffer is empty');
+  const head = buf.subarray(0, 5).toString('latin1');
+  if (head !== '%PDF-') throw new Error(`Buffer is not a PDF (header was "${head}")`);
+  const tail = buf.subarray(-1024).toString('latin1');
+  if (!tail.includes('%%EOF')) throw new Error('PDF is missing %%EOF trailer');
+  const matches = buf.toString('latin1').match(/\/Type\s*\/Page[^s]/g);
+  return matches ? matches.length : 0;
+}

--- a/tests/e2e/helpers/session.ts
+++ b/tests/e2e/helpers/session.ts
@@ -1,0 +1,31 @@
+import { type Page, expect } from '@playwright/test';
+import { createClient } from '@supabase/supabase-js';
+import { e2eEnv } from './env';
+import { waitForAppReady } from '../pages/common';
+
+function projectRef(url: string): string {
+  return new URL(url).hostname.split('.')[0];
+}
+
+/**
+ * Sign a page's browser context in as the given Supabase user by injecting the
+ * session into localStorage (the app login UI has no password field). Reusable
+ * across contexts — used by multi-user tests to drive a second member. Leaves
+ * the page on '/' authenticated and ready.
+ */
+export async function signInAs(page: Page, email: string, password: string): Promise<void> {
+  const env = e2eEnv(['SUPABASE_URL', 'SUPABASE_ANON_KEY'] as const);
+  const node = createClient(env.SUPABASE_URL, env.SUPABASE_ANON_KEY, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  const { data, error } = await node.auth.signInWithPassword({ email, password });
+  if (error || !data.session) throw new Error(`signInWithPassword failed for ${email}: ${error?.message}`);
+  const key = `sb-${projectRef(env.SUPABASE_URL)}-auth-token`;
+  const value = JSON.stringify(data.session);
+
+  await page.goto('/');
+  await page.evaluate((a: { key: string; value: string }) => window.localStorage.setItem(a.key, a.value), { key, value });
+  await page.reload();
+  await expect(page.locator('#user-info')).toBeVisible({ timeout: 15_000 });
+  await waitForAppReady(page);
+}

--- a/tests/e2e/helpers/supabase-admin.test.ts
+++ b/tests/e2e/helpers/supabase-admin.test.ts
@@ -1,0 +1,19 @@
+import { e2eEnv } from './env';
+try { e2eEnv(['SUPABASE_SERVICE_ROLE_KEY']); } catch {}
+
+import { describe, it, expect, afterAll } from 'vitest';
+import { createEphemeralIdentity, destroyEphemeralIdentity, type EphemeralIdentity } from './supabase-admin';
+
+const RUN = process.env.SUPABASE_SERVICE_ROLE_KEY ? describe : describe.skip;
+let id: EphemeralIdentity;
+
+RUN('ephemeral identity lifecycle', () => {
+  it('creates a user + workspace + membership', async () => {
+    id = await createEphemeralIdentity('lifecycle');
+    expect(id.userId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(id.workspaceId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(id.email).toContain('@');
+    expect(id.password.length).toBeGreaterThan(12);
+  });
+  afterAll(async () => { if (id) await destroyEphemeralIdentity(id); });
+});

--- a/tests/e2e/helpers/supabase-admin.test.ts
+++ b/tests/e2e/helpers/supabase-admin.test.ts
@@ -4,7 +4,12 @@ try { e2eEnv(['SUPABASE_SERVICE_ROLE_KEY']); } catch {}
 import { describe, it, expect, afterAll } from 'vitest';
 import { createEphemeralIdentity, destroyEphemeralIdentity, type EphemeralIdentity } from './supabase-admin';
 
-const RUN = process.env.SUPABASE_SERVICE_ROLE_KEY ? describe : describe.skip;
+// This is a LIVE integration test: it provisions and destroys a real ephemeral
+// identity in the Supabase project. It is NOT part of the default `npm test`
+// (which must stay hermetic). Opt in explicitly once the service_role DML grant
+// migration is applied:
+//   E2E_DB_INTEGRATION=1 npx vitest run tests/e2e/helpers/supabase-admin.test.ts
+const RUN = process.env.E2E_DB_INTEGRATION ? describe : describe.skip;
 let id: EphemeralIdentity;
 
 RUN('ephemeral identity lifecycle', () => {

--- a/tests/e2e/helpers/supabase-admin.ts
+++ b/tests/e2e/helpers/supabase-admin.ts
@@ -1,6 +1,22 @@
-import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient, type User } from '@supabase/supabase-js';
 import { randomUUID } from 'node:crypto';
 import { e2eEnv } from './env';
+
+/** List ALL auth users (paginates past the 1000/page cap). */
+async function listAllUsers(sb: SupabaseClient): Promise<User[]> {
+  const all: User[] = [];
+  let page = 1;
+  for (;;) {
+    const { data } = await sb.auth.admin.listUsers({ page, perPage: 1000 });
+    const users = data?.users ?? [];
+    if (!users.length) break;
+    all.push(...users);
+    const nextPage = (data as { nextPage?: number }).nextPage;
+    if (!nextPage) break;
+    page = nextPage;
+  }
+  return all;
+}
 
 export interface EphemeralIdentity {
   userId: string;
@@ -50,6 +66,11 @@ export async function createEphemeralIdentity(label: string): Promise<EphemeralI
 }
 
 export async function destroyEphemeralIdentity(id: EphemeralIdentity): Promise<void> {
+  // Defense in depth: never delete anything that isn't a disposable identity,
+  // even if core-ids.json is stale/corrupted.
+  if (!id.email?.startsWith('e2e-eph-') || !id.workspaceId || !id.userId) {
+    throw new Error(`refusing to destroy non-ephemeral identity: ${JSON.stringify(id)}`);
+  }
   const sb = admin();
   await sb.from('projects').delete().eq('workspace_id', id.workspaceId);
   await sb.from('workspace_members').delete().eq('workspace_id', id.workspaceId);
@@ -70,8 +91,7 @@ export async function sweepStaleEphemeralIdentities(): Promise<void> {
     await sb.from('workspace_members').delete().eq('workspace_id', ws.id);
     await sb.from('workspaces').delete().eq('id', ws.id);
   }
-  const { data: list } = await sb.auth.admin.listUsers({ perPage: 1000 });
-  for (const u of list?.users ?? []) {
+  for (const u of await listAllUsers(sb)) {
     if (u.email?.startsWith('e2e-eph-')) await sb.auth.admin.deleteUser(u.id);
   }
 }
@@ -103,8 +123,7 @@ export async function ensureLiveWorkspaceMember(opts: {
   const workspaceId = mem.workspace_id as string;
 
   // 2. Ensure the persistent e2e-live user exists with the known password.
-  const { data: list } = await sb.auth.admin.listUsers({ perPage: 1000 });
-  let liveUser = list?.users?.find((u) => u.email === opts.liveEmail) ?? null;
+  let liveUser = (await listAllUsers(sb)).find((u) => u.email === opts.liveEmail) ?? null;
   if (!liveUser) {
     const { data: created, error: cErr } = await sb.auth.admin.createUser({
       email: opts.liveEmail, password: opts.livePassword, email_confirm: true,

--- a/tests/e2e/helpers/supabase-admin.ts
+++ b/tests/e2e/helpers/supabase-admin.ts
@@ -97,6 +97,41 @@ export async function sweepStaleEphemeralIdentities(): Promise<void> {
 }
 
 /**
+ * Create a disposable extra member in an EXISTING workspace (for multi-user
+ * tests like read-only / conflict). Does NOT create a workspace. Clean up with
+ * removeWorkspaceMember — NOT destroyEphemeralIdentity (which deletes the shared
+ * workspace). Email is `e2e-eph-` prefixed so the sweep also catches it.
+ */
+export async function createWorkspaceMember(
+  workspaceId: string,
+  role: 'viewer' | 'editor' | 'owner',
+): Promise<EphemeralIdentity> {
+  const sb = admin();
+  const tag = randomUUID().slice(0, 8);
+  const email = `e2e-eph-member-${tag}@e2e.bulletin.test`;
+  const password = `E2e-${randomUUID()}`;
+  const { data: created, error } = await sb.auth.admin.createUser({ email, password, email_confirm: true });
+  if (error || !created.user) throw new Error(`createUser failed: ${error?.message}`);
+  const userId = created.user.id;
+  await sb.from('profiles').upsert({ id: userId, email }, { onConflict: 'id' });
+  const { error: memErr } = await sb
+    .from('workspace_members')
+    .upsert({ workspace_id: workspaceId, user_id: userId, role }, { onConflict: 'workspace_id,user_id' });
+  if (memErr) throw new Error(`member upsert failed: ${memErr.message}`);
+  return { userId, workspaceId, email, password };
+}
+
+/** Remove an extra member created by createWorkspaceMember (membership + auth user only). */
+export async function removeWorkspaceMember(id: EphemeralIdentity): Promise<void> {
+  if (!id.email?.startsWith('e2e-eph-')) {
+    throw new Error(`refusing to remove non-ephemeral user: ${id.email}`);
+  }
+  const sb = admin();
+  await sb.from('workspace_members').delete().eq('workspace_id', id.workspaceId).eq('user_id', id.userId);
+  await sb.auth.admin.deleteUser(id.userId);
+}
+
+/**
  * Ensure a PERSISTENT `e2e-live` user exists and is a member of the owner's
  * (worship@'s) workspace, so the live lane inherits that workspace's already-
  * connected PCO/Google tokens (tokens are stored per-workspace). Idempotent.

--- a/tests/e2e/helpers/supabase-admin.ts
+++ b/tests/e2e/helpers/supabase-admin.ts
@@ -20,7 +20,9 @@ function admin(): SupabaseClient {
 export async function createEphemeralIdentity(label: string): Promise<EphemeralIdentity> {
   const sb = admin();
   const tag = randomUUID().slice(0, 8);
-  const email = `e2e-${label}-${tag}@e2e.bulletin.test`;
+  // `e2e-eph-` prefix marks DISPOSABLE identities the sweep may delete. The
+  // persistent live user (`e2e-live@`) deliberately does NOT match this prefix.
+  const email = `e2e-eph-${label}-${tag}@e2e.bulletin.test`;
   const password = `E2e-${randomUUID()}`;
 
   const { data: created, error: userErr } = await sb.auth.admin.createUser({
@@ -33,7 +35,7 @@ export async function createEphemeralIdentity(label: string): Promise<EphemeralI
 
   const { data: ws, error: wsErr } = await sb
     .from('workspaces')
-    .insert({ name: `E2E ${tag}`, slug: `e2e-${tag}`, created_by_user_id: userId })
+    .insert({ name: `E2E-EPH ${tag}`, slug: `e2e-eph-${tag}`, created_by_user_id: userId })
     .select('id')
     .single();
   if (wsErr || !ws) throw new Error(`workspace insert failed: ${wsErr?.message}`);
@@ -61,7 +63,8 @@ export async function destroyEphemeralIdentity(id: EphemeralIdentity): Promise<v
  */
 export async function sweepStaleEphemeralIdentities(): Promise<void> {
   const sb = admin();
-  const { data: stale } = await sb.from('workspaces').select('id').like('slug', 'e2e-%');
+  // Only `e2e-eph-` (disposable) rows — never the persistent `e2e-live` member.
+  const { data: stale } = await sb.from('workspaces').select('id').like('slug', 'e2e-eph-%');
   for (const ws of stale ?? []) {
     await sb.from('projects').delete().eq('workspace_id', ws.id);
     await sb.from('workspace_members').delete().eq('workspace_id', ws.id);
@@ -69,6 +72,55 @@ export async function sweepStaleEphemeralIdentities(): Promise<void> {
   }
   const { data: list } = await sb.auth.admin.listUsers({ perPage: 1000 });
   for (const u of list?.users ?? []) {
-    if (u.email?.startsWith('e2e-')) await sb.auth.admin.deleteUser(u.id);
+    if (u.email?.startsWith('e2e-eph-')) await sb.auth.admin.deleteUser(u.id);
   }
+}
+
+/**
+ * Ensure a PERSISTENT `e2e-live` user exists and is a member of the owner's
+ * (worship@'s) workspace, so the live lane inherits that workspace's already-
+ * connected PCO/Google tokens (tokens are stored per-workspace). Idempotent.
+ * Does NOT touch the owner account. Returns the resolved workspace id.
+ */
+export async function ensureLiveWorkspaceMember(opts: {
+  liveEmail: string;
+  livePassword: string;
+  ownerEmail: string;
+}): Promise<{ workspaceId: string; liveUserId: string }> {
+  const sb = admin();
+
+  // 1. Resolve the owner's workspace via profiles -> workspace_members.
+  const { data: ownerProfile, error: pErr } = await sb
+    .from('profiles').select('id').eq('email', opts.ownerEmail).single();
+  if (pErr || !ownerProfile) {
+    throw new Error(`owner profile not found for ${opts.ownerEmail}: ${pErr?.message}`);
+  }
+  const { data: mem, error: mErr } = await sb
+    .from('workspace_members').select('workspace_id').eq('user_id', ownerProfile.id).limit(1).single();
+  if (mErr || !mem) {
+    throw new Error(`no workspace membership for ${opts.ownerEmail}: ${mErr?.message}`);
+  }
+  const workspaceId = mem.workspace_id as string;
+
+  // 2. Ensure the persistent e2e-live user exists with the known password.
+  const { data: list } = await sb.auth.admin.listUsers({ perPage: 1000 });
+  let liveUser = list?.users?.find((u) => u.email === opts.liveEmail) ?? null;
+  if (!liveUser) {
+    const { data: created, error: cErr } = await sb.auth.admin.createUser({
+      email: opts.liveEmail, password: opts.livePassword, email_confirm: true,
+    });
+    if (cErr || !created.user) throw new Error(`create e2e-live user failed: ${cErr?.message}`);
+    liveUser = created.user;
+  } else {
+    await sb.auth.admin.updateUserById(liveUser.id, { password: opts.livePassword });
+  }
+  await sb.from('profiles').upsert({ id: liveUser.id, email: opts.liveEmail }, { onConflict: 'id' });
+
+  // 3. Ensure viewer membership in the owner's workspace (read-only).
+  const { error: upErr } = await sb
+    .from('workspace_members')
+    .upsert({ workspace_id: workspaceId, user_id: liveUser.id, role: 'viewer' }, { onConflict: 'workspace_id,user_id' });
+  if (upErr) throw new Error(`live membership upsert failed: ${upErr.message}`);
+
+  return { workspaceId, liveUserId: liveUser.id };
 }

--- a/tests/e2e/helpers/supabase-admin.ts
+++ b/tests/e2e/helpers/supabase-admin.ts
@@ -1,0 +1,74 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { randomUUID } from 'node:crypto';
+import { e2eEnv } from './env';
+
+export interface EphemeralIdentity {
+  userId: string;
+  workspaceId: string;
+  email: string;
+  password: string;
+}
+
+function admin(): SupabaseClient {
+  const env = e2eEnv(['SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY'] as const);
+  return createClient(env.SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+}
+
+/** Create an isolated user + workspace + owner membership. RLS-bypassing (service_role). */
+export async function createEphemeralIdentity(label: string): Promise<EphemeralIdentity> {
+  const sb = admin();
+  const tag = randomUUID().slice(0, 8);
+  const email = `e2e-${label}-${tag}@e2e.bulletin.test`;
+  const password = `E2e-${randomUUID()}`;
+
+  const { data: created, error: userErr } = await sb.auth.admin.createUser({
+    email, password, email_confirm: true,
+  });
+  if (userErr || !created.user) throw new Error(`createUser failed: ${userErr?.message}`);
+  const userId = created.user.id;
+
+  await sb.from('profiles').upsert({ id: userId, email }, { onConflict: 'id' });
+
+  const { data: ws, error: wsErr } = await sb
+    .from('workspaces')
+    .insert({ name: `E2E ${tag}`, slug: `e2e-${tag}`, created_by_user_id: userId })
+    .select('id')
+    .single();
+  if (wsErr || !ws) throw new Error(`workspace insert failed: ${wsErr?.message}`);
+  const workspaceId = ws.id as string;
+
+  const { error: memErr } = await sb
+    .from('workspace_members')
+    .insert({ workspace_id: workspaceId, user_id: userId, role: 'owner' });
+  if (memErr) throw new Error(`membership insert failed: ${memErr.message}`);
+
+  return { userId, workspaceId, email, password };
+}
+
+export async function destroyEphemeralIdentity(id: EphemeralIdentity): Promise<void> {
+  const sb = admin();
+  await sb.from('projects').delete().eq('workspace_id', id.workspaceId);
+  await sb.from('workspace_members').delete().eq('workspace_id', id.workspaceId);
+  await sb.from('workspaces').delete().eq('id', id.workspaceId);
+  await sb.auth.admin.deleteUser(id.userId);
+}
+
+/**
+ * Safety net for the single-live-project model: delete any `e2e-`-prefixed
+ * leftovers a prior failed teardown left behind. ONLY touches `e2e-` rows.
+ */
+export async function sweepStaleEphemeralIdentities(): Promise<void> {
+  const sb = admin();
+  const { data: stale } = await sb.from('workspaces').select('id').like('slug', 'e2e-%');
+  for (const ws of stale ?? []) {
+    await sb.from('projects').delete().eq('workspace_id', ws.id);
+    await sb.from('workspace_members').delete().eq('workspace_id', ws.id);
+    await sb.from('workspaces').delete().eq('id', ws.id);
+  }
+  const { data: list } = await sb.auth.admin.listUsers({ perPage: 1000 });
+  for (const u of list?.users ?? []) {
+    if (u.email?.startsWith('e2e-')) await sb.auth.admin.deleteUser(u.id);
+  }
+}

--- a/tests/e2e/pages/AppShell.ts
+++ b/tests/e2e/pages/AppShell.ts
@@ -1,0 +1,39 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+
+const TABS = {
+  editor: 'page-editor',
+  files: 'page-files',
+  songdb: 'page-songdb',
+  format: 'page-format',
+  templates: 'page-templates',
+  settings: 'page-settings',
+} as const;
+export type TabName = keyof typeof TABS;
+
+export class AppShell {
+  constructor(private readonly page: Page) {}
+
+  async goto(): Promise<void> {
+    await this.page.goto('/');
+    await expect(this.page.locator('.tab-bar')).toBeVisible();
+  }
+
+  tab(name: TabName): Locator {
+    return this.page.locator(`[data-tab="${TABS[name]}"]`);
+  }
+
+  async switchTo(name: TabName): Promise<void> {
+    await this.tab(name).click();
+    await expect(this.tab(name)).toHaveAttribute('aria-selected', 'true');
+  }
+
+  /**
+   * Assert the server-mode session is authenticated. Uses UI signals, NOT
+   * page.request — page.request is a separate context that does not run the
+   * app's JS, so it never attaches the supabase Bearer token that apiFetch adds.
+   */
+  async expectAuthenticated(): Promise<void> {
+    await expect(this.page.locator('#login-screen')).toBeHidden();
+    await expect(this.page.locator('#user-info')).toBeVisible();
+  }
+}

--- a/tests/e2e/pages/AppShell.ts
+++ b/tests/e2e/pages/AppShell.ts
@@ -20,6 +20,9 @@ export class AppShell {
     // initTabSemantics() marks the default (editor) tab aria-selected="true";
     // wait for that so click handlers are attached before we interact.
     await expect(this.page.locator('[data-tab="page-editor"]')).toHaveAttribute('aria-selected', 'true');
+    // Wait for restoreOnStartup() (async server load + project/draft restore) to
+    // finish, or its late re-apply would wipe edits we make immediately after.
+    await this.page.waitForFunction(() => (window as { __BG_READY__?: boolean }).__BG_READY__ === true, undefined, { timeout: 15_000 });
   }
 
   tab(name: TabName): Locator {

--- a/tests/e2e/pages/AppShell.ts
+++ b/tests/e2e/pages/AppShell.ts
@@ -16,6 +16,10 @@ export class AppShell {
   async goto(): Promise<void> {
     await this.page.goto('/');
     await expect(this.page.locator('.tab-bar')).toBeVisible();
+    // The tab system is wired by the async legacy-script loader AFTER `load`.
+    // initTabSemantics() marks the default (editor) tab aria-selected="true";
+    // wait for that so click handlers are attached before we interact.
+    await expect(this.page.locator('[data-tab="page-editor"]')).toHaveAttribute('aria-selected', 'true');
   }
 
   tab(name: TabName): Locator {

--- a/tests/e2e/pages/EditorPage.ts
+++ b/tests/e2e/pages/EditorPage.ts
@@ -1,0 +1,62 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+import { expandSection, row } from './common';
+
+/** The Booklet Editor — Order of Worship item list and the live preview. */
+export class EditorPage {
+  constructor(private readonly page: Page) {}
+
+  /** Expand the (initially collapsed) Order of Worship section. */
+  async openOrderOfWorship(): Promise<void> {
+    await expandSection(this.page, 'Order of Worship');
+  }
+
+  items(): Locator {
+    return this.page.locator('[data-testid="item-row"]');
+  }
+
+  item(index: number): Locator {
+    return row(this.page, 'item', index);
+  }
+
+  preview(): Locator {
+    return this.page.locator('#preview-pane');
+  }
+
+  async addItem(): Promise<void> {
+    const before = await this.items().count();
+    await this.page.locator('#add-item-btn').click();
+    await expect(this.items()).toHaveCount(before + 1);
+  }
+
+  async addPageBreak(): Promise<void> {
+    const before = await this.items().count();
+    await this.page.locator('#add-break-btn').click();
+    await expect(this.items()).toHaveCount(before + 1);
+  }
+
+  async setTitle(index: number, title: string): Promise<void> {
+    await this.item(index).locator('.item-title-input').fill(title);
+  }
+
+  async setType(index: number, type: string): Promise<void> {
+    await this.item(index).locator('.item-type-select').selectOption(type);
+  }
+
+  async setDetail(index: number, text: string): Promise<void> {
+    await this.item(index).locator('.item-detail-input').fill(text);
+  }
+
+  async moveUp(index: number): Promise<void> {
+    await this.item(index).locator('[data-action="up"]').click();
+  }
+
+  async moveDown(index: number): Promise<void> {
+    await this.item(index).locator('[data-action="down"]').click();
+  }
+
+  async deleteItem(index: number): Promise<void> {
+    const before = await this.items().count();
+    await this.item(index).locator('[data-action="delete"]').click();
+    await expect(this.items()).toHaveCount(before - 1);
+  }
+}

--- a/tests/e2e/pages/ProjectsPage.ts
+++ b/tests/e2e/pages/ProjectsPage.ts
@@ -1,0 +1,41 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+
+/** The Projects (Files) tab — saved-project list and per-card actions. */
+export class ProjectsPage {
+  constructor(private readonly page: Page) {}
+
+  list(): Locator {
+    return this.page.locator('#files-list');
+  }
+
+  cards(): Locator {
+    return this.page.locator('#files-list .file-card');
+  }
+
+  /** A project card located by its visible name. */
+  cardByName(name: string): Locator {
+    return this.page
+      .locator('#files-list .file-card')
+      .filter({ has: this.page.locator('.file-card-name', { hasText: name }) });
+  }
+
+  /** Load a project into the editor via its card's Load button. */
+  async loadByName(name: string): Promise<void> {
+    await this.cardByName(name).locator('[data-fm="load"]').click();
+  }
+
+  /** Delete a project via its card's Delete button (native confirm auto-accepted). */
+  async deleteByName(name: string): Promise<void> {
+    await this.cardByName(name).locator('[data-fm="delete"]').click();
+    await expect(this.cardByName(name)).toHaveCount(0);
+  }
+
+  /** Select a project's checkbox (drives the bulk-actions bar). */
+  async toggleSelect(name: string): Promise<void> {
+    await this.cardByName(name).locator('.file-card-cb').click();
+  }
+
+  bulkBar(): Locator {
+    return this.page.locator('#bulk-bar');
+  }
+}

--- a/tests/e2e/pages/SongDbPage.ts
+++ b/tests/e2e/pages/SongDbPage.ts
@@ -1,0 +1,40 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+
+/** The Song Database tab — add/search/delete songs. */
+export class SongDbPage {
+  constructor(private readonly page: Page) {}
+
+  search(): Locator {
+    return this.page.locator('#song-db-search');
+  }
+
+  rows(): Locator {
+    return this.page.locator('[data-testid="song-db-row"]');
+  }
+
+  rowByTitle(title: string): Locator {
+    return this.page
+      .locator('[data-testid="song-db-row"]')
+      .filter({ has: this.page.locator('.song-db-entry-title', { hasText: title }) });
+  }
+
+  /** Fill the add-song form and save; waits for the /api/songs POST to land. */
+  async add(title: string, author: string, lyrics: string, copyright: string): Promise<void> {
+    await this.page.locator('#sdb-title').fill(title);
+    await this.page.locator('#sdb-author').fill(author);
+    await this.page.locator('#sdb-lyrics').fill(lyrics);
+    await this.page.locator('#sdb-copyright').fill(copyright);
+    const saved = this.page.waitForResponse(
+      (r) => r.url().includes('/api/songs') && r.request().method() === 'POST' && r.ok(),
+      { timeout: 15_000 },
+    );
+    await this.page.locator('#sdb-save-btn').click();
+    await saved;
+  }
+
+  /** Delete a song via its row's delete button (native confirm auto-accepted). */
+  async deleteByTitle(title: string): Promise<void> {
+    await this.rowByTitle(title).getByTitle('Delete song').click();
+    await expect(this.rowByTitle(title)).toHaveCount(0);
+  }
+}

--- a/tests/e2e/pages/common.ts
+++ b/tests/e2e/pages/common.ts
@@ -36,3 +36,18 @@ export async function createAndSaveProject(page: Page, name: string): Promise<vo
 export function row(page: Page, area: string, index: number): Locator {
   return page.locator(`[data-testid="${area}-row"][data-index="${index}"]`);
 }
+
+/**
+ * Expand an editor sidebar section card (they start collapsed; editor.js:595).
+ * Clicking the `.section-label` toggles `.collapsed`. Idempotent.
+ */
+export async function expandSection(page: Page, labelText: string): Promise<Locator> {
+  const section = page
+    .locator('aside .panel-section')
+    .filter({ has: page.locator('.section-label', { hasText: labelText }) })
+    .first();
+  const collapsed = await section.evaluate((el) => el.classList.contains('collapsed'));
+  if (collapsed) await section.locator('.section-label').first().click();
+  await expect(section).not.toHaveClass(/(^|\s)collapsed(\s|$)/);
+  return section;
+}

--- a/tests/e2e/pages/common.ts
+++ b/tests/e2e/pages/common.ts
@@ -1,5 +1,13 @@
 import { type Page, type Locator, expect } from '@playwright/test';
 
+/** Wait for the app's async startup (restoreOnStartup) to finish. Needed after
+ *  page.reload(), where the readiness flag resets until startup re-completes. */
+export async function waitForAppReady(page: Page): Promise<void> {
+  await page.waitForFunction(() => (window as { __BG_READY__?: boolean }).__BG_READY__ === true, undefined, {
+    timeout: 15_000,
+  });
+}
+
 const TOOLBAR_MENU_IDS = {
   file: 'editor-toolbar-file',
   sync: 'editor-toolbar-sync',

--- a/tests/e2e/pages/common.ts
+++ b/tests/e2e/pages/common.ts
@@ -1,0 +1,38 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+
+const TOOLBAR_MENU_IDS = {
+  file: 'editor-toolbar-file',
+  sync: 'editor-toolbar-sync',
+  document: 'editor-toolbar-document',
+} as const;
+export type ToolbarMenu = keyof typeof TOOLBAR_MENU_IDS;
+
+/** Open one of the editor toolbar <details> dropdowns (idempotent). */
+export async function openToolbarMenu(page: Page, menu: ToolbarMenu): Promise<void> {
+  const id = TOOLBAR_MENU_IDS[menu];
+  const details = page.locator(`#${id}`);
+  const isOpen = await details.evaluate((el) => (el as HTMLDetailsElement).open);
+  if (!isOpen) await page.locator(`#${id} summary`).click();
+  await expect(details).toHaveJSProperty('open', true);
+}
+
+/**
+ * The canonical "make a persistable project" flow. Autosave only fires once a
+ * project is active (projects.js:345), so most specs must call this first.
+ * Opens the File menu, names the bulletin, clicks Save, and awaits the POST.
+ */
+export async function createAndSaveProject(page: Page, name: string): Promise<void> {
+  await openToolbarMenu(page, 'file');
+  await page.locator('#bulletin-title').fill(name);
+  const saved = page.waitForResponse(
+    (r) => r.url().includes('/api/projects') && r.request().method() === 'POST' && r.ok(),
+    { timeout: 15_000 },
+  );
+  await page.locator('#project-save-btn').click();
+  await saved;
+}
+
+/** Locator for a dynamic row by its data-testid area + numeric index. */
+export function row(page: Page, area: string, index: number): Locator {
+  return page.locator(`[data-testid="${area}-row"][data-index="${index}"]`);
+}

--- a/tsconfig.e2e.json
+++ b/tsconfig.e2e.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "ES2022",
     "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM"],
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/tsconfig.e2e.json
+++ b/tsconfig.e2e.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["tests/e2e/**/*.ts", "playwright.config.ts"]
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -23,6 +23,6 @@ export default defineConfig({
     setupFiles: ['./vitest.setup.js'],
     // Never scan agent worktrees or deps — they hold stale duplicate specs
     // that inflate counts and can false-fail if the copies diverge from HEAD.
-    exclude: ['**/node_modules/**', '**/.claude/**', '**/dist/**'],
+    exclude: ['**/node_modules/**', '**/.claude/**', '**/dist/**', 'tests/e2e/**/*.spec.ts'],
   },
 });


### PR DESCRIPTION
## Summary

Stacks the Playwright E2E test foundation (two-lane core/live suite, page objects, vertical-slice specs) on top of the Supabase multi-tenant branch (#276), **plus** a bug the new Projects spec surfaced.

## Presence endpoint 500 fix (the headline bug)

`workspace_presences.project_id` was declared `uuid`, but project ids are application-generated **TEXT** (`proj_<ts>_<rand>`) and `public.projects.id` is `text`. Binding a TEXT id against the uuid column raised `psycopg.errors.InvalidTextRepresentation`, returning **500 on every `GET /api/presence` and `POST /api/presence/heartbeat`** for real projects — silently, because the frontend swallows presence errors (best-effort). Presence was fully broken for all projects.

**Fix:** additive, idempotent migration [`supabase/migrations/20260605000002_presence_project_id_text.sql`](supabase/migrations/20260605000002_presence_project_id_text.sql) altering the column to `text` (lossless uuid→text widening; PK + index rebuilt automatically). No handler query change needed — the handlers bind `project_id` as a plain string with no `::uuid` cast. Corrected the now-misleading `<uuid>` docstrings so the assumption isn't reintroduced.

Applied live to the Supabase project.

## Verification

- Live column `workspace_presences.project_id` `data_type = text`.
- Faithful DB round-trip through the exact heartbeat-upsert + GET query shapes with a TEXT `proj_...` id → returns the row, **no `InvalidTextRepresentation`** (old uuid column would have raised).
- `ai-workflow checks --level issue` and `--level pr` both PASS (vite build + pytest + vitest).
- Surfaced by `tests/e2e/features/projects.spec.ts`.

## Manual smoke (handoff)

Full HTTP-level confirmation needs a live auth session: open a project as a workspace member and confirm `GET /api/presence` returns 200 (and the 30s heartbeat POST succeeds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)