### PR TITLE
feat(desktop): #277-C supabase-data.js renderer data layer (anon key)

### DIFF
--- a/docs/ai/contracts/issue-277-C.json
+++ b/docs/ai/contracts/issue-277-C.json
@@ -1,0 +1,178 @@
+{
+  "issue": "issue-277-C",
+  "title": "Renderer-side Supabase data-access module (supabase-data.js)",
+  "generated": "2026-06-06",
+  "context": "Issue #277-C of the S2-hybrid migration. Creates src/js/supabase-data.js — a renderer-side module that performs all project/data CRUD directly via the Supabase JS client (supabase.from(...)/supabase.rpc(...)) under the signed-in user's JWT so that RLS is enforced end-to-end. Replaces the current apiFetch('/api/...') → Python sidecar (psycopg) path. THIS SUB-ISSUE ONLY creates the module + unit tests; wiring into call sites is 277-D.",
+  "stack": "javascript",
+  "criteria": [
+    {
+      "criterion_id": "issue-277-C-c1",
+      "text": "sdGetProjects() calls from('projects').select(...).order('updated_at', {ascending:false}) and returns the unwrapped data array; throws on error.",
+      "mode": "unit",
+      "test_file": "tests/supabase-data.spec.js",
+      "test_id": "sdGetProjects > calls projects.select with the correct columns and returns data",
+      "status": "pass"
+    },
+    {
+      "criterion_id": "issue-277-C-c2",
+      "text": "sdGetProject(id) calls from('projects').select(...).eq('id', id).single() and returns the single project; throws on error.",
+      "mode": "unit",
+      "test_file": "tests/supabase-data.spec.js",
+      "test_id": "sdGetProject > calls projects table with eq(id) and returns a single project",
+      "status": "pass"
+    },
+    {
+      "criterion_id": "issue-277-C-c3",
+      "text": "sdSaveProject(project) calls from('projects').upsert(payload, {onConflict:'id'}) with the correct fields (id, name, state, owner_user_id, workspace_id, visibility); throws on error.",
+      "mode": "unit",
+      "test_file": "tests/supabase-data.spec.js",
+      "test_id": "sdSaveProject > upserts project with the correct columns",
+      "status": "pass"
+    },
+    {
+      "criterion_id": "issue-277-C-c4",
+      "text": "sdDeleteProject(id) calls from('projects').delete().eq('id', id); throws on error.",
+      "mode": "unit",
+      "test_file": "tests/supabase-data.spec.js",
+      "test_id": "sdDeleteProject > calls delete on projects table with the project id",
+      "status": "pass"
+    },
+    {
+      "criterion_id": "issue-277-C-c5",
+      "text": "sdTransferProject(projectId, toUserId) calls rpc('transfer_project_owner', { p_project_id, p_to_user_id }) with the correct RPC param names (from 277-B); throws on error.",
+      "mode": "unit",
+      "test_file": "tests/supabase-data.spec.js",
+      "test_id": "sdTransferProject > calls rpc transfer_project_owner with the correct param names",
+      "status": "pass"
+    },
+    {
+      "criterion_id": "issue-277-C-c6",
+      "text": "sdGetProjectHistory(id) calls from('project_revisions').select(...).eq('project_id', id).order('revision_number', {ascending:false}); throws on error.",
+      "mode": "unit",
+      "test_file": "tests/supabase-data.spec.js",
+      "test_id": "sdGetProjectHistory > queries project_revisions with the project_id filter",
+      "status": "pass"
+    },
+    {
+      "criterion_id": "issue-277-C-c7",
+      "text": "sdRestoreProject(id, revisionNumber) fetches the revision snapshot from project_revisions and upserts its state back into projects; throws when revision not found.",
+      "mode": "unit",
+      "test_file": "tests/supabase-data.spec.js",
+      "test_id": "sdRestoreProject > fetches the revision state and upserts it as the current project state",
+      "status": "pass"
+    },
+    {
+      "criterion_id": "issue-277-C-c8",
+      "text": "sdGetAnnouncements() calls from('announcements').select(...).order('created_at', {ascending:true}) and returns the data array; throws on error.",
+      "mode": "unit",
+      "test_file": "tests/supabase-data.spec.js",
+      "test_id": "sdGetAnnouncements > queries the announcements table and returns the data array",
+      "status": "pass"
+    },
+    {
+      "criterion_id": "issue-277-C-c9",
+      "text": "sdSaveAnnouncements(data) calls from('announcements').upsert(rows) with the correct fields; throws on error.",
+      "mode": "unit",
+      "test_file": "tests/supabase-data.spec.js",
+      "test_id": "sdSaveAnnouncements > upserts each announcement with the required fields",
+      "status": "pass"
+    },
+    {
+      "criterion_id": "issue-277-C-c10",
+      "text": "sdGetSongs() calls from('songs').select(...).order('title', {ascending:true}) and returns the data array; throws on error.",
+      "mode": "unit",
+      "test_file": "tests/supabase-data.spec.js",
+      "test_id": "sdGetSongs > queries the songs table ordered by title",
+      "status": "pass"
+    },
+    {
+      "criterion_id": "issue-277-C-c11",
+      "text": "sdSaveSongs(data) calls from('songs').upsert(rows) without calling delete (additive, mirrors save_songs in storage.py); throws on error.",
+      "mode": "unit",
+      "test_file": "tests/supabase-data.spec.js",
+      "test_id": "sdSaveSongs > upserts songs without deleting existing rows",
+      "status": "pass"
+    },
+    {
+      "criterion_id": "issue-277-C-c12",
+      "text": "sdGetSettings() calls from('workspace_settings').select('workspace_id, settings') and returns the row(s); throws on error.",
+      "mode": "unit",
+      "test_file": "tests/supabase-data.spec.js",
+      "test_id": "sdGetSettings > queries workspace_settings and returns the settings blob",
+      "status": "pass"
+    },
+    {
+      "criterion_id": "issue-277-C-c13",
+      "text": "sdSaveSettings(settings) calls from('workspace_settings').upsert({settings}) with the settings object; throws on error.",
+      "mode": "unit",
+      "test_file": "tests/supabase-data.spec.js",
+      "test_id": "sdSaveSettings > upserts into workspace_settings with the settings blob",
+      "status": "pass"
+    },
+    {
+      "criterion_id": "issue-277-C-c14",
+      "text": "sdGetMembers() calls from('workspace_members').select('user_id, role, profiles(display_name, email)') and returns the data; throws on error.",
+      "mode": "unit",
+      "test_file": "tests/supabase-data.spec.js",
+      "test_id": "sdGetMembers > queries workspace_members with profiles join",
+      "status": "pass"
+    },
+    {
+      "criterion_id": "issue-277-C-c15",
+      "text": "sdGetPresence(projectId) calls from('workspace_presences').select(...).eq('project_id', projectId) and returns the data; throws on error.",
+      "mode": "unit",
+      "test_file": "tests/supabase-data.spec.js",
+      "test_id": "sdGetPresence > queries workspace_presences filtered by project_id",
+      "status": "pass"
+    },
+    {
+      "criterion_id": "issue-277-C-c16",
+      "text": "sdPostPresenceHeartbeat(projectId) calls from('workspace_presences').upsert({project_id, last_seen_at}) with the project_id; throws on error.",
+      "mode": "unit",
+      "test_file": "tests/supabase-data.spec.js",
+      "test_id": "sdPostPresenceHeartbeat > upserts a presence row for the given project_id",
+      "status": "pass"
+    },
+    {
+      "criterion_id": "issue-277-C-c17",
+      "text": "sdDeletePresence({userId}) calls from('workspace_presences').delete().eq('user_id', userId); throws on error.",
+      "mode": "unit",
+      "test_file": "tests/supabase-data.spec.js",
+      "test_id": "sdDeletePresence > deletes workspace_presences for the current user",
+      "status": "pass"
+    },
+    {
+      "criterion_id": "issue-277-C-c18",
+      "text": "sdGetTemplates() calls from('templates').select('id, name, template_data, is_default') with is_default DESC, name ASC ordering; throws on error.",
+      "mode": "unit",
+      "test_file": "tests/supabase-data.spec.js",
+      "test_id": "sdGetTemplates > queries the templates table ordered by is_default desc, name asc",
+      "status": "pass"
+    },
+    {
+      "criterion_id": "issue-277-C-c19",
+      "text": "sdSaveTemplates(data) filters out default/built-in templates (is_default, built_in, builtIn) before upserting; throws on error.",
+      "mode": "unit",
+      "test_file": "tests/supabase-data.spec.js",
+      "test_id": "sdSaveTemplates > upserts non-default templates only (skips built-ins)",
+      "status": "pass"
+    },
+    {
+      "criterion_id": "issue-277-C-c20",
+      "text": "node --check src/js/supabase-data.js passes with no syntax errors.",
+      "mode": "unit",
+      "test_file": "src/js/supabase-data.js",
+      "test_id": "node --check",
+      "status": "pass"
+    }
+  ],
+  "not_tested": [
+    "LIMITATION: sdRestoreProject does not enforce a CAS check on client_revision (the Python handler uses save_project_transactional with WHERE revision=?). For conflict-safe restore, wire through a Postgres function in 277-D.",
+    "LIMITATION: sdSaveAnnouncements is upsert-only (not DELETE+INSERT). The Python handler does a full workspace replacement (DELETE WHERE workspace_id=? then INSERT all). Full-replace via supabase-js requires two round-trips or an RPC — flagged for 277-D.",
+    "LIMITATION: sdGetPresence does not enforce the 90-second TTL filter at the DB level. The Python handler uses WHERE last_seen_at > now() - interval '90 seconds'. With supabase-js this requires .gt('last_seen_at', isoTimestamp) — caller must apply the filter, or use an RPC in 277-D.",
+    "LIMITATION: sdSaveSettings requires workspace_id to be passed explicitly from session context. The Python handler resolves workspace_id from the authenticated user's claims — 277-D must supply it from the session.",
+    "LIMITATION: sdDeletePresence without a userId arg will delete all presence rows for the user (no workspace_id filter). Production callers must pass userId from session — flagged for 277-D.",
+    "LIVE RLS round-trip: real network call with a signed JWT to verify RLS policies scope data to the authenticated user's workspace — manual smoke only.",
+    "LIVE: sdTransferProject via a real DB with transfer_project_owner RPC installed — requires 277-B RPC to be applied."
+  ]
+}

--- a/src/js/supabase-data.js
+++ b/src/js/supabase-data.js
@@ -1,0 +1,656 @@
+/**
+ * supabase-data.js — Renderer-side Supabase data-access module (issue #277-C)
+ *
+ * Performs all project/data CRUD directly via the Supabase JS client
+ * (supabase.from(...) / supabase.rpc(...)) using the signed-in user's JWT
+ * so that RLS is enforced end-to-end.
+ *
+ * This module is a DROP-IN replacement for the apiFetch('/api/...') → Python
+ * sidecar path. Call-site wiring (projects.js, announcements.js, etc.) is
+ * handled in issue #277-D.
+ *
+ * ── Client resolution ────────────────────────────────────────────────────────
+ * Each exported function accepts an optional `opts` / `client` argument for
+ * testability (dependency injection). In production the client is resolved via
+ * _getSupabaseClient() from auth-ui.js (available on globalThis after that
+ * module loads), which creates the @supabase/supabase-js client from
+ * BULLETIN_SUPABASE_CONFIG (url + anonKey).
+ *
+ * ── Error handling ───────────────────────────────────────────────────────────
+ * Supabase returns { data, error }. Every function throws when error is truthy
+ * so callers can catch uniformly.
+ *
+ * ── Table/column assumptions (verified against storage.py) ──────────────────
+ *
+ * projects:
+ *   id TEXT, workspace_id uuid, owner_user_id uuid, name text,
+ *   visibility text ('workspace'|'private'), state jsonb,
+ *   revision int, created_at timestamptz, updated_at timestamptz,
+ *   created_by_user_id uuid, updated_by_user_id uuid
+ *
+ * project_revisions:
+ *   id uuid, project_id text, revision_number int, state jsonb,
+ *   created_at timestamptz, created_by_user_id uuid, summary text,
+ *   workspace_id uuid
+ *
+ * announcements:
+ *   id uuid, workspace_id uuid, title text, body text, state jsonb,
+ *   created_at timestamptz, updated_at timestamptz, created_by_user_id uuid
+ *
+ * songs:
+ *   id uuid, workspace_id uuid, title text, data jsonb,
+ *   created_at timestamptz, updated_at timestamptz
+ *
+ * workspace_settings:
+ *   workspace_id uuid, settings jsonb
+ *
+ * workspace_members:
+ *   workspace_id uuid, user_id uuid, role text ('owner'|'editor'|'viewer')
+ *
+ * workspace_presences:
+ *   workspace_id uuid, user_id uuid (PK composite: workspace_id,user_id,project_id),
+ *   project_id text, display_name text, last_seen_at timestamptz
+ *
+ * templates:
+ *   id uuid, workspace_id uuid, name text, template_data jsonb, is_default bool
+ *
+ * ── Limitations (noted for 277-D) ────────────────────────────────────────────
+ * sdRestoreProject: the Python handler uses save_project_transactional (a
+ *   multi-step UPDATE+INSERT that checks client_revision for CAS semantics).
+ *   The supabase-js client has no native multi-statement transaction; this
+ *   implementation fetches the revision state and upserts it via sdSaveProject,
+ *   which increments the revision (safe) but does NOT enforce a CAS check on
+ *   the current revision. In 277-D, if conflict-free restore is required, wire
+ *   through a Postgres function / Edge Function.
+ *
+ * sdSaveAnnouncements: the Python handler does DELETE+INSERT (full replacement).
+ *   The supabase-js implementation uses upsert (additive) without a preceding
+ *   delete. A full-replace via supabase-js requires two round-trips
+ *   (delete then insert) or an RPC. Marked as a 277-D concern.
+ */
+
+// ---------------------------------------------------------------------------
+// Internal: client resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the Supabase client. Used internally when no client is injected.
+ *
+ * Resolution order (mirrors how auth-ui.js creates the client):
+ * 1. Call _getSupabaseClient() if it is available on globalThis (auth-ui.js
+ *    exports it there after it first initialises).
+ * 2. Otherwise fall back to calling globalThis.supabase?.createClient with
+ *    BULLETIN_SUPABASE_CONFIG — enabling pre-auth usage if needed.
+ *
+ * Returns null in desktop mode (BULLETIN_SUPABASE_CONFIG absent) so callers
+ * can detect the no-op desktop path.
+ */
+function _resolveClient() {
+  // Prefer the already-initialised singleton from auth-ui.js (carries the
+  // user's session so all requests include the JWT).
+  if (typeof globalThis._getSupabaseClient === 'function') {
+    return globalThis._getSupabaseClient();
+  }
+  // Fallback: construct from config (e.g. early-init callers).
+  const config = globalThis.BULLETIN_SUPABASE_CONFIG || {};
+  const createClient =
+    typeof createSupabaseClient === 'function'  // vitest shim
+      ? createSupabaseClient
+      : globalThis.supabase?.createClient;
+  if (!config.url || !config.anonKey || typeof createClient !== 'function') {
+    return null;
+  }
+  return createClient(config.url, config.anonKey, {
+    auth: { persistSession: true, autoRefreshToken: true },
+  });
+}
+
+/**
+ * Throw a normalised error for a Supabase { data, error } response.
+ * @param {{ data: any, error: object|null }} result
+ * @param {string} [context]  - extra context for the error message
+ */
+function _throwIfError(result, context = '') {
+  if (result && result.error) {
+    const msg = result.error.message || result.error.code || 'Supabase error';
+    const err = new Error(context ? `${context}: ${msg}` : msg);
+    err.code = result.error.code || null;
+    err.details = result.error.details || null;
+    throw err;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Projects
+// ---------------------------------------------------------------------------
+
+/**
+ * List all projects visible to the current user (RLS scopes the result).
+ *
+ * Mirrors: GET /api/projects → storage.list_projects_for_user()
+ *
+ * Columns returned: id, name, owner_user_id, visibility, state, revision,
+ *   created_at, updated_at, updated_by_user_id + profiles join for attribution.
+ * Note: the full `state` JSONB is included (unlike the Python list path which
+ * omits it for performance). In 277-D, consider a lighter select for the
+ * file-picker list.
+ *
+ * @param {{ client?: object }} [opts]
+ * @returns {Promise<object[]>}
+ */
+export async function sdGetProjects({ client } = {}) {
+  const sb = client || _resolveClient();
+  const result = await sb
+    .from('projects')
+    .select(
+      'id, name, owner_user_id, visibility, state, revision, ' +
+      'created_at, updated_at, created_by_user_id, updated_by_user_id',
+    )
+    .order('updated_at', { ascending: false });
+  _throwIfError(result, 'sdGetProjects');
+  return result.data;
+}
+
+/**
+ * Fetch a single project by its TEXT id.
+ *
+ * Mirrors: GET /api/projects → storage.get_project(id)
+ *
+ * @param {string} id - TEXT project id (proj_<ts>_<rand>)
+ * @param {{ client?: object }} [opts]
+ * @returns {Promise<object>}
+ */
+export async function sdGetProject(id, { client } = {}) {
+  const sb = client || _resolveClient();
+  const result = await sb
+    .from('projects')
+    .select(
+      'id, name, owner_user_id, visibility, state, revision, ' +
+      'created_at, updated_at, created_by_user_id, updated_by_user_id',
+    )
+    .eq('id', id)
+    .single();
+  _throwIfError(result, `sdGetProject(${id})`);
+  return result.data;
+}
+
+/**
+ * Upsert (insert or update) a project.
+ *
+ * Mirrors: POST /api/projects → storage.save_project()
+ *
+ * The `state` field must be the full project payload (same shape stored in
+ * the JSONB column). On INSERT revision defaults to 1 via the DB default;
+ * on UPDATE supabase-js does not auto-increment — pass onConflict so the
+ * DB default triggers. For true revision-increment on update, use an RPC
+ * (flagged for 277-D).
+ *
+ * Required fields: id (TEXT), name (text), state (object), workspace_id (uuid).
+ * Optional: owner_user_id (uuid), visibility ('workspace'|'private').
+ *
+ * @param {object} project
+ * @param {{ client?: object }} [opts]
+ * @returns {Promise<object>}  the saved project row
+ */
+export async function sdSaveProject(project, { client } = {}) {
+  const sb = client || _resolveClient();
+  const payload = {
+    id: project.id,
+    name: project.name || '',
+    state: project.state ?? project,  // full project is the state
+    owner_user_id: project.owner_user_id || null,
+    workspace_id: project.workspace_id || null,
+    visibility: project.visibility || 'workspace',
+    updated_at: new Date().toISOString(),
+  };
+  const result = await sb
+    .from('projects')
+    .upsert(payload, { onConflict: 'id' });
+  _throwIfError(result, 'sdSaveProject');
+  // Return the first row of the result data (or the payload if no RETURNING)
+  return (result.data && result.data[0]) || payload;
+}
+
+/**
+ * Delete a project by id.
+ *
+ * Mirrors: DELETE /api/projects → storage.delete_project()
+ *
+ * @param {string} id
+ * @param {{ client?: object }} [opts]
+ * @returns {Promise<void>}
+ */
+export async function sdDeleteProject(id, { client } = {}) {
+  const sb = client || _resolveClient();
+  const result = await sb
+    .from('projects')
+    .delete()
+    .eq('id', id);
+  _throwIfError(result, `sdDeleteProject(${id})`);
+}
+
+/**
+ * Transfer project ownership to another workspace member.
+ *
+ * Calls the `transfer_project_owner` RPC added in 277-B.
+ * Param names: p_project_id, p_to_user_id (confirmed from the RPC spec).
+ *
+ * Mirrors: POST /api/projects/{id}/transfer
+ *
+ * @param {string} projectId
+ * @param {string} toUserId
+ * @param {{ client?: object }} [opts]
+ * @returns {Promise<object>}  updated project
+ */
+export async function sdTransferProject(projectId, toUserId, { client } = {}) {
+  const sb = client || _resolveClient();
+  const result = await sb.rpc('transfer_project_owner', {
+    p_project_id: projectId,
+    p_to_user_id: toUserId,
+  });
+  _throwIfError(result, `sdTransferProject(${projectId} → ${toUserId})`);
+  return result.data;
+}
+
+// ---------------------------------------------------------------------------
+// Project revisions
+// ---------------------------------------------------------------------------
+
+/**
+ * Return revision metadata for a project, newest first.
+ *
+ * Mirrors: GET /api/projects/{id}/revisions → storage.get_project_revisions()
+ *
+ * Columns: id, project_id, revision_number, summary, created_at,
+ *   created_by_user_id (+ profiles join for display_name/email handled by RLS view
+ *   or manually in 277-D).
+ *
+ * @param {string} projectId
+ * @param {{ client?: object }} [opts]
+ * @returns {Promise<object[]>}
+ */
+export async function sdGetProjectHistory(projectId, { client } = {}) {
+  const sb = client || _resolveClient();
+  const result = await sb
+    .from('project_revisions')
+    .select('id, project_id, revision_number, summary, created_at, created_by_user_id, state')
+    .eq('project_id', projectId)
+    .order('revision_number', { ascending: false });
+  _throwIfError(result, `sdGetProjectHistory(${projectId})`);
+  return result.data;
+}
+
+/**
+ * Restore a project to a prior revision by fetching the snapshot state and
+ * saving it as the new head.
+ *
+ * LIMITATION: The Python handler uses save_project_transactional (CAS check
+ * on client_revision). This implementation does NOT enforce a CAS check —
+ * it is a simple fetch-then-upsert. For transactional restore with conflict
+ * detection, wire through a Postgres function in 277-D.
+ *
+ * Mirrors: POST /api/projects/{id}/restore
+ *
+ * @param {string} projectId
+ * @param {number} revisionNumber
+ * @param {{ client?: object }} [opts]
+ * @returns {Promise<object>}  updated project
+ */
+export async function sdRestoreProject(projectId, revisionNumber, { client } = {}) {
+  const sb = client || _resolveClient();
+  // 1. Fetch the target revision snapshot
+  const revResult = await sb
+    .from('project_revisions')
+    .select('id, project_id, revision_number, state')
+    .eq('project_id', projectId)
+    .eq('revision_number', revisionNumber)
+    .single();
+  _throwIfError(revResult, `sdRestoreProject fetch revision(${revisionNumber})`);
+
+  const snapshot = revResult.data;
+  const state = snapshot && snapshot.state;
+  if (!state || typeof state !== 'object') {
+    throw new Error(`sdRestoreProject: revision ${revisionNumber} has invalid state`);
+  }
+
+  // 2. Save the snapshot state as the new head (no CAS — see limitation above)
+  return sdSaveProject({ ...state, id: projectId }, { client: sb });
+}
+
+// ---------------------------------------------------------------------------
+// Announcements
+// ---------------------------------------------------------------------------
+
+/**
+ * List all announcements for the current workspace, ordered by created_at ASC.
+ *
+ * Mirrors: GET /api/announcements → storage.list_announcements()
+ *
+ * Columns: id, workspace_id, title, body, state, created_at, updated_at,
+ *   created_by_user_id
+ *
+ * @param {{ client?: object }} [opts]
+ * @returns {Promise<object[]>}
+ */
+export async function sdGetAnnouncements({ client } = {}) {
+  const sb = client || _resolveClient();
+  const result = await sb
+    .from('announcements')
+    .select('id, workspace_id, title, body, state, created_at, updated_at, created_by_user_id')
+    .order('created_at', { ascending: true });
+  _throwIfError(result, 'sdGetAnnouncements');
+  return result.data;
+}
+
+/**
+ * Save (upsert) the announcements list.
+ *
+ * LIMITATION: The Python handler does DELETE + INSERT (full replacement).
+ * This implementation upserts without deleting — items removed from the list
+ * on the client will persist in the DB until a delete is issued explicitly.
+ * For full-replace behaviour, use an RPC or two round-trips in 277-D.
+ *
+ * Mirrors: POST /api/announcements → storage.save_announcements()
+ *
+ * @param {object[]} data
+ * @param {{ client?: object }} [opts]
+ * @returns {Promise<object[]>}  the upserted rows
+ */
+export async function sdSaveAnnouncements(data, { client } = {}) {
+  const sb = client || _resolveClient();
+  const rows = (Array.isArray(data) ? data : []).map(item => ({
+    id: item.id || undefined,
+    title: item.title || '',
+    body: item.body || '',
+    state: item,       // full item dict stored in state JSONB (mirrors Python)
+  }));
+  const result = await sb
+    .from('announcements')
+    .upsert(rows, { onConflict: 'id' });
+  _throwIfError(result, 'sdSaveAnnouncements');
+  return result.data || rows;
+}
+
+// ---------------------------------------------------------------------------
+// Songs
+// ---------------------------------------------------------------------------
+
+/**
+ * List all songs for the current workspace, ordered by title ASC.
+ *
+ * Mirrors: GET /api/songs (bootstrap) → storage.list_songs()
+ *
+ * Columns: id, workspace_id, title, data, created_at, updated_at
+ *
+ * @param {{ client?: object }} [opts]
+ * @returns {Promise<object[]>}
+ */
+export async function sdGetSongs({ client } = {}) {
+  const sb = client || _resolveClient();
+  const result = await sb
+    .from('songs')
+    .select('id, workspace_id, title, data, created_at, updated_at')
+    .order('title', { ascending: true });
+  _throwIfError(result, 'sdGetSongs');
+  return result.data;
+}
+
+/**
+ * Upsert songs (additive — never deletes existing rows).
+ *
+ * Mirrors: POST /api/songs → storage.save_songs()
+ * (save_songs is additive: it upserts each song individually, never deletes.)
+ *
+ * @param {object[]} data
+ * @param {{ client?: object }} [opts]
+ * @returns {Promise<object[]>}
+ */
+export async function sdSaveSongs(data, { client } = {}) {
+  const sb = client || _resolveClient();
+  const rows = (Array.isArray(data) ? data : []).map(item => ({
+    id: item.id || undefined,
+    title: item.title || '',
+    data: item,  // full song dict stored in data JSONB (mirrors Python)
+  }));
+  const result = await sb
+    .from('songs')
+    .upsert(rows, { onConflict: 'id' });
+  _throwIfError(result, 'sdSaveSongs');
+  return result.data || rows;
+}
+
+// ---------------------------------------------------------------------------
+// Settings
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch workspace settings blob.
+ *
+ * Mirrors: GET /api/settings → storage.get_settings()
+ *
+ * Returns the raw row(s) — callers should read result[0].settings for the blob.
+ * RLS scopes to the current user's workspace.
+ *
+ * @param {{ client?: object }} [opts]
+ * @returns {Promise<object[]>}
+ */
+export async function sdGetSettings({ client } = {}) {
+  const sb = client || _resolveClient();
+  const result = await sb
+    .from('workspace_settings')
+    .select('workspace_id, settings');
+  _throwIfError(result, 'sdGetSettings');
+  return result.data;
+}
+
+/**
+ * Save the workspace settings blob.
+ *
+ * Mirrors: POST /api/settings → storage.save_settings()
+ *
+ * RLS requires the row's workspace_id matches auth.uid()'s workspace.
+ * workspace_id is omitted from the payload — the DB constraint / RLS resolves it.
+ * In 277-D, the workspace_id must be supplied from the session context.
+ *
+ * @param {object} settings  - the full settings dict
+ * @param {{ client?: object, workspaceId?: string }} [opts]
+ * @returns {Promise<object[]>}
+ */
+export async function sdSaveSettings(settings, { client, workspaceId } = {}) {
+  const sb = client || _resolveClient();
+  const payload = { settings };
+  if (workspaceId) payload.workspace_id = workspaceId;
+  const result = await sb
+    .from('workspace_settings')
+    .upsert(payload, { onConflict: 'workspace_id' });
+  _throwIfError(result, 'sdSaveSettings');
+  return result.data || [payload];
+}
+
+// ---------------------------------------------------------------------------
+// Workspace members
+// ---------------------------------------------------------------------------
+
+/**
+ * List workspace members with profile info.
+ *
+ * Mirrors: GET /api/workspace/members → server._handle_get_workspace_members()
+ * (uses admin_transaction in Python — RLS may limit this; confirm RLS policy
+ * for workspace_members SELECT in 277-D.)
+ *
+ * Columns: user_id, role + profiles(display_name, email)
+ *
+ * @param {{ client?: object }} [opts]
+ * @returns {Promise<object[]>}
+ */
+export async function sdGetMembers({ client } = {}) {
+  const sb = client || _resolveClient();
+  const result = await sb
+    .from('workspace_members')
+    .select('user_id, role, profiles(display_name, email)');
+  _throwIfError(result, 'sdGetMembers');
+  return result.data;
+}
+
+// ---------------------------------------------------------------------------
+// Presence
+// ---------------------------------------------------------------------------
+
+/**
+ * Get active presence records for a project (last_seen_at within 90 seconds).
+ *
+ * Mirrors: GET /api/presence?project_id=X → server._handle_get_presence()
+ *
+ * The 90-second TTL filter is enforced server-side in the Python handler via
+ * SQL (last_seen_at > now() - interval '90 seconds'). With supabase-js the
+ * filter must be applied via an RPC or a computed column, or post-filtered
+ * client-side. This implementation returns all presence rows for the project
+ * and lets the caller filter by last_seen_at if needed. A proper TTL filter
+ * via supabase-js requires .gt('last_seen_at', <iso>) or an RPC — flagged for
+ * 277-D.
+ *
+ * @param {string} projectId
+ * @param {{ client?: object }} [opts]
+ * @returns {Promise<object[]>}  [{ user_id, display_name, last_seen_at }, ...]
+ */
+export async function sdGetPresence(projectId, { client } = {}) {
+  const sb = client || _resolveClient();
+  const result = await sb
+    .from('workspace_presences')
+    .select('user_id, display_name, last_seen_at')
+    .eq('project_id', projectId)
+    .order('last_seen_at', { ascending: false });
+  _throwIfError(result, `sdGetPresence(${projectId})`);
+  return result.data;
+}
+
+/**
+ * Upsert a presence heartbeat row for the current user + project.
+ *
+ * Mirrors: POST /api/presence/heartbeat
+ *
+ * workspace_id and user_id are omitted here — they must be supplied from
+ * session context in 277-D (or included via a DB trigger / RLS default).
+ *
+ * @param {string} projectId
+ * @param {{ client?: object, userId?: string, workspaceId?: string }} [opts]
+ * @returns {Promise<void>}
+ */
+export async function sdPostPresenceHeartbeat(projectId, { client, userId, workspaceId } = {}) {
+  const sb = client || _resolveClient();
+  const payload = {
+    project_id: projectId,
+    last_seen_at: new Date().toISOString(),
+  };
+  if (userId) payload.user_id = userId;
+  if (workspaceId) payload.workspace_id = workspaceId;
+  const result = await sb
+    .from('workspace_presences')
+    .upsert(payload, { onConflict: 'workspace_id,user_id,project_id' });
+  _throwIfError(result, `sdPostPresenceHeartbeat(${projectId})`);
+}
+
+/**
+ * Delete the current user's presence rows (called on project close / sign-out).
+ *
+ * Mirrors: DELETE /api/presence → server._handle_delete_presence()
+ *
+ * @param {{ client?: object, userId?: string }} [opts]
+ * @returns {Promise<void>}
+ */
+export async function sdDeletePresence({ client, userId } = {}) {
+  const sb = client || _resolveClient();
+  const q = sb.from('workspace_presences').delete();
+  if (userId) {
+    q.eq('user_id', userId);
+  }
+  const result = await q;
+  _throwIfError(result, 'sdDeletePresence');
+}
+
+// ---------------------------------------------------------------------------
+// Templates
+// ---------------------------------------------------------------------------
+
+/**
+ * List all templates, ordered by is_default DESC, name ASC.
+ *
+ * Mirrors: GET /api/templates → storage.list_templates()
+ *
+ * Columns: id, name, template_data, is_default
+ *
+ * @param {{ client?: object }} [opts]
+ * @returns {Promise<object[]>}
+ */
+export async function sdGetTemplates({ client } = {}) {
+  const sb = client || _resolveClient();
+  const result = await sb
+    .from('templates')
+    .select('id, name, template_data, is_default')
+    .order('is_default', { ascending: false })
+    .order('name', { ascending: true });
+  _throwIfError(result, 'sdGetTemplates');
+  return result.data;
+}
+
+/**
+ * Upsert custom templates; default/built-in templates are never modified.
+ *
+ * Mirrors: POST /api/templates → storage.save_templates()
+ *
+ * @param {object[]} data
+ * @param {{ client?: object }} [opts]
+ * @returns {Promise<object[]>}
+ */
+export async function sdSaveTemplates(data, { client } = {}) {
+  const sb = client || _resolveClient();
+  // Filter out built-in/default templates — never overwrite them (mirrors Python)
+  const custom = (Array.isArray(data) ? data : []).filter(
+    t => !t.is_default && !t.built_in && !t.builtIn,
+  );
+  if (custom.length === 0) {
+    return [];
+  }
+  const rows = custom.map(item => ({
+    id: item.id || undefined,
+    name: item.name || '',
+    template_data: item,
+    is_default: false,
+  }));
+  const result = await sb
+    .from('templates')
+    .upsert(rows, { onConflict: 'id' });
+  _throwIfError(result, 'sdSaveTemplates');
+  return result.data || rows;
+}
+
+// ---------------------------------------------------------------------------
+// Module export (dual pattern: ESM named exports + CommonJS for vitest)
+// ---------------------------------------------------------------------------
+
+// Named ESM exports are declared above (export function ...).
+// The CommonJS path below allows vitest (which uses Node's require() path for
+// non-bundled CJS interop) to import the module without a bundler.
+if (typeof module !== 'undefined' && module.exports) {
+  Object.assign(module.exports, {
+    sdGetProjects,
+    sdGetProject,
+    sdSaveProject,
+    sdDeleteProject,
+    sdTransferProject,
+    sdGetProjectHistory,
+    sdRestoreProject,
+    sdGetAnnouncements,
+    sdSaveAnnouncements,
+    sdGetSongs,
+    sdSaveSongs,
+    sdGetSettings,
+    sdSaveSettings,
+    sdGetMembers,
+    sdGetPresence,
+    sdPostPresenceHeartbeat,
+    sdDeletePresence,
+    sdGetTemplates,
+    sdSaveTemplates,
+  });
+}

--- a/tests/supabase-data.spec.js
+++ b/tests/supabase-data.spec.js
@@ -1,0 +1,574 @@
+/**
+ * supabase-data.spec.js
+ * Unit tests for src/js/supabase-data.js — renderer-side Supabase data-access module.
+ *
+ * Strategy: dependency-injection. Every exported function accepts an optional
+ * `client` argument so these tests pass in a fully-mocked supabase client.
+ * No network calls, no real DB.
+ *
+ * Mock client shape:
+ *   client.from(table) → chainable builder { select, eq, order, insert, upsert, update, delete }
+ *   client.rpc(name, params) → thenable { data, error }
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  sdGetProjects,
+  sdGetProject,
+  sdSaveProject,
+  sdDeleteProject,
+  sdTransferProject,
+  sdGetProjectHistory,
+  sdRestoreProject,
+  sdGetAnnouncements,
+  sdSaveAnnouncements,
+  sdGetSongs,
+  sdSaveSongs,
+  sdGetSettings,
+  sdSaveSettings,
+  sdGetMembers,
+  sdGetPresence,
+  sdPostPresenceHeartbeat,
+  sdDeletePresence,
+  sdGetTemplates,
+  sdSaveTemplates,
+} from '../src/js/supabase-data.js';
+
+// ---------------------------------------------------------------------------
+// Mock-client factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a chainable mock for client.from(table).
+ *
+ * @param {object} opts  { data, error }  — resolved at the end of the chain
+ */
+function makeMockFrom(opts = { data: [], error: null }) {
+  const chain = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    neq: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+    upsert: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    delete: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue(opts),
+    // make the chain itself awaitable for non-single queries
+    then: (resolve) => resolve(opts),
+  };
+  return chain;
+}
+
+/**
+ * Build a complete mock Supabase client.
+ *
+ * @param {object} fromResult  default { data, error } returned by from()
+ * @param {object} rpcResult   default { data, error } returned by rpc()
+ */
+function makeMockClient(
+  fromResult = { data: [], error: null },
+  rpcResult = { data: null, error: null },
+) {
+  const fromFn = vi.fn(() => makeMockFrom(fromResult));
+  const rpcFn = vi.fn(async () => rpcResult);
+  return { from: fromFn, rpc: rpcFn };
+}
+
+// ---------------------------------------------------------------------------
+// Projects
+// ---------------------------------------------------------------------------
+
+describe('sdGetProjects', () => {
+  it('calls projects.select with the correct columns and returns data', async () => {
+    const mockProjects = [{ id: 'proj_abc', name: 'Test', visibility: 'workspace' }];
+    const chain = makeMockFrom({ data: mockProjects, error: null });
+    const client = { from: vi.fn(() => chain), rpc: vi.fn() };
+
+    const result = await sdGetProjects({ client });
+
+    expect(client.from).toHaveBeenCalledWith('projects');
+    expect(chain.select).toHaveBeenCalled();
+    expect(chain.order).toHaveBeenCalledWith('updated_at', expect.objectContaining({ ascending: false }));
+    expect(result).toEqual(mockProjects);
+  });
+
+  it('throws when supabase returns an error', async () => {
+    const chain = makeMockFrom({ data: null, error: { message: 'DB error' } });
+    const client = { from: vi.fn(() => chain), rpc: vi.fn() };
+
+    await expect(sdGetProjects({ client })).rejects.toThrow('DB error');
+  });
+});
+
+describe('sdGetProject', () => {
+  it('calls projects table with eq(id) and returns a single project', async () => {
+    const mockProject = { id: 'proj_123', name: 'My Bulletin', state: { items: [] } };
+    const chain = makeMockFrom({ data: mockProject, error: null });
+    const client = { from: vi.fn(() => chain), rpc: vi.fn() };
+
+    const result = await sdGetProject('proj_123', { client });
+
+    expect(client.from).toHaveBeenCalledWith('projects');
+    expect(chain.select).toHaveBeenCalled();
+    expect(chain.eq).toHaveBeenCalledWith('id', 'proj_123');
+    expect(chain.single).toHaveBeenCalled();
+    expect(result).toEqual(mockProject);
+  });
+
+  it('throws when project is not found (error from supabase)', async () => {
+    const chain = makeMockFrom({ data: null, error: { message: 'Not found', code: 'PGRST116' } });
+    const client = { from: vi.fn(() => chain), rpc: vi.fn() };
+
+    await expect(sdGetProject('proj_missing', { client })).rejects.toThrow();
+  });
+});
+
+describe('sdSaveProject', () => {
+  it('upserts project with the correct columns', async () => {
+    const project = {
+      id: 'proj_abc',
+      name: 'My Bulletin',
+      state: { items: [{ type: 'song', title: 'Amazing Grace' }] },
+      owner_user_id: 'user-uuid-1',
+      workspace_id: 'ws-uuid-1',
+      visibility: 'workspace',
+    };
+    const saved = { ...project, revision: 2 };
+    const chain = makeMockFrom({ data: [saved], error: null });
+    const client = { from: vi.fn(() => chain), rpc: vi.fn() };
+
+    const result = await sdSaveProject(project, { client });
+
+    expect(client.from).toHaveBeenCalledWith('projects');
+    expect(chain.upsert).toHaveBeenCalled();
+    // Verify upsert payload includes key project fields
+    const upsertArg = chain.upsert.mock.calls[0][0];
+    expect(upsertArg).toMatchObject({
+      id: 'proj_abc',
+      name: 'My Bulletin',
+    });
+    expect(result).toEqual(saved);
+  });
+
+  it('throws on supabase error during save', async () => {
+    const chain = makeMockFrom({ data: null, error: { message: 'constraint violation' } });
+    const client = { from: vi.fn(() => chain), rpc: vi.fn() };
+
+    await expect(sdSaveProject({ id: 'proj_x', name: 'Test' }, { client })).rejects.toThrow('constraint violation');
+  });
+});
+
+describe('sdDeleteProject', () => {
+  it('calls delete on projects table with the project id', async () => {
+    const chain = makeMockFrom({ data: null, error: null });
+    const client = { from: vi.fn(() => chain), rpc: vi.fn() };
+
+    await sdDeleteProject('proj_abc', { client });
+
+    expect(client.from).toHaveBeenCalledWith('projects');
+    expect(chain.delete).toHaveBeenCalled();
+    expect(chain.eq).toHaveBeenCalledWith('id', 'proj_abc');
+  });
+
+  it('throws on supabase error during delete', async () => {
+    const chain = makeMockFrom({ data: null, error: { message: 'permission denied' } });
+    const client = { from: vi.fn(() => chain), rpc: vi.fn() };
+
+    await expect(sdDeleteProject('proj_abc', { client })).rejects.toThrow('permission denied');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Transfer
+// ---------------------------------------------------------------------------
+
+describe('sdTransferProject', () => {
+  it('calls rpc transfer_project_owner with the correct param names', async () => {
+    const client = makeMockClient(undefined, { data: { id: 'proj_abc', owner_user_id: 'user-2' }, error: null });
+
+    const result = await sdTransferProject('proj_abc', 'user-2', { client });
+
+    expect(client.rpc).toHaveBeenCalledWith('transfer_project_owner', {
+      p_project_id: 'proj_abc',
+      p_to_user_id: 'user-2',
+    });
+    expect(result).toMatchObject({ owner_user_id: 'user-2' });
+  });
+
+  it('throws when rpc returns an error', async () => {
+    const client = makeMockClient(undefined, { data: null, error: { message: 'not owner' } });
+
+    await expect(sdTransferProject('proj_abc', 'user-2', { client })).rejects.toThrow('not owner');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Project history
+// ---------------------------------------------------------------------------
+
+describe('sdGetProjectHistory', () => {
+  it('queries project_revisions with the project_id filter', async () => {
+    const mockRevisions = [
+      { id: 'rev-1', project_id: 'proj_abc', revision_number: 2, created_at: '2026-06-01' },
+      { id: 'rev-2', project_id: 'proj_abc', revision_number: 1, created_at: '2026-05-30' },
+    ];
+    const chain = makeMockFrom({ data: mockRevisions, error: null });
+    const client = { from: vi.fn(() => chain), rpc: vi.fn() };
+
+    const result = await sdGetProjectHistory('proj_abc', { client });
+
+    expect(client.from).toHaveBeenCalledWith('project_revisions');
+    expect(chain.select).toHaveBeenCalled();
+    expect(chain.eq).toHaveBeenCalledWith('project_id', 'proj_abc');
+    expect(chain.order).toHaveBeenCalledWith('revision_number', expect.objectContaining({ ascending: false }));
+    expect(result).toEqual(mockRevisions);
+  });
+
+  it('throws on supabase error', async () => {
+    const chain = makeMockFrom({ data: null, error: { message: 'forbidden' } });
+    const client = { from: vi.fn(() => chain), rpc: vi.fn() };
+
+    await expect(sdGetProjectHistory('proj_abc', { client })).rejects.toThrow('forbidden');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sdRestoreProject — minimal: fetch revision state + upsert as new head
+// ---------------------------------------------------------------------------
+
+describe('sdRestoreProject', () => {
+  it('fetches the revision state and upserts it as the current project state', async () => {
+    const revisionState = { id: 'proj_abc', name: 'My Bulletin', items: [] };
+    const revisionData = {
+      id: 'rev-2', project_id: 'proj_abc', revision_number: 1, state: revisionState,
+    };
+    // First from() call is for project_revisions (single), second for projects (upsert)
+    let callCount = 0;
+    const revisionChain = makeMockFrom({ data: revisionData, error: null });
+    const upsertChain = makeMockFrom({ data: [{ id: 'proj_abc', name: 'My Bulletin', revision: 3 }], error: null });
+    const client = {
+      from: vi.fn(() => {
+        callCount++;
+        return callCount === 1 ? revisionChain : upsertChain;
+      }),
+      rpc: vi.fn(),
+    };
+
+    const result = await sdRestoreProject('proj_abc', 1, { client });
+
+    // Should have queried project_revisions
+    expect(client.from).toHaveBeenCalledWith('project_revisions');
+    // Should have upserted back into projects
+    expect(client.from).toHaveBeenCalledWith('projects');
+    expect(result).toMatchObject({ id: 'proj_abc' });
+  });
+
+  it('throws when the target revision is not found', async () => {
+    const chain = makeMockFrom({ data: null, error: { message: 'Not found', code: 'PGRST116' } });
+    const client = { from: vi.fn(() => chain), rpc: vi.fn() };
+
+    await expect(sdRestoreProject('proj_abc', 99, { client })).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Announcements
+// ---------------------------------------------------------------------------
+
+describe('sdGetAnnouncements', () => {
+  it('queries the announcements table and returns the data array', async () => {
+    const mockAnns = [{ id: 'ann-1', title: 'Event', body: 'Join us', state: {} }];
+    const chain = makeMockFrom({ data: mockAnns, error: null });
+    const client = { from: vi.fn(() => chain), rpc: vi.fn() };
+
+    const result = await sdGetAnnouncements({ client });
+
+    expect(client.from).toHaveBeenCalledWith('announcements');
+    expect(chain.select).toHaveBeenCalled();
+    expect(chain.order).toHaveBeenCalledWith('created_at', expect.objectContaining({ ascending: true }));
+    expect(result).toEqual(mockAnns);
+  });
+
+  it('throws on supabase error', async () => {
+    const chain = makeMockFrom({ data: null, error: { message: 'rls fail' } });
+    const client = { from: vi.fn(() => chain), rpc: vi.fn() };
+
+    await expect(sdGetAnnouncements({ client })).rejects.toThrow('rls fail');
+  });
+});
+
+describe('sdSaveAnnouncements', () => {
+  it('upserts each announcement with the required fields', async () => {
+    const anns = [
+      { id: 'ann-1', title: 'Potluck', body: 'Join us Sunday', url: '' },
+    ];
+    const chain = makeMockFrom({ data: anns, error: null });
+    const client = { from: vi.fn(() => chain), rpc: vi.fn() };
+
+    const result = await sdSaveAnnouncements(anns, { client });
+
+    expect(client.from).toHaveBeenCalledWith('announcements');
+    expect(chain.upsert).toHaveBeenCalled();
+    const upsertArg = chain.upsert.mock.calls[0][0];
+    expect(Array.isArray(upsertArg)).toBe(true);
+    expect(upsertArg[0]).toMatchObject({ id: 'ann-1', title: 'Potluck' });
+    expect(result).toEqual(anns);
+  });
+
+  it('throws on supabase error during save', async () => {
+    const chain = makeMockFrom({ data: null, error: { message: 'constraint error' } });
+    const client = { from: vi.fn(() => chain), rpc: vi.fn() };
+
+    await expect(sdSaveAnnouncements([{ title: 'test' }], { client })).rejects.toThrow('constraint error');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Songs
+// ---------------------------------------------------------------------------
+
+describe('sdGetSongs', () => {
+  it('queries the songs table ordered by title', async () => {
+    const mockSongs = [{ id: 'song-1', title: 'Amazing Grace', data: {} }];
+    const chain = makeMockFrom({ data: mockSongs, error: null });
+    const client = { from: vi.fn(() => chain), rpc: vi.fn() };
+
+    const result = await sdGetSongs({ client });
+
+    expect(client.from).toHaveBeenCalledWith('songs');
+    expect(chain.select).toHaveBeenCalled();
+    expect(chain.order).toHaveBeenCalledWith('title', expect.objectContaining({ ascending: true }));
+    expect(result).toEqual(mockSongs);
+  });
+
+  it('throws on supabase error', async () => {
+    const chain = makeMockFrom({ data: null, error: { message: 'db fail' } });
+    const client = { from: vi.fn(() => chain), rpc: vi.fn() };
+
+    await expect(sdGetSongs({ client })).rejects.toThrow('db fail');
+  });
+});
+
+describe('sdSaveSongs', () => {
+  it('upserts songs without deleting existing rows', async () => {
+    const songs = [{ id: 'song-1', title: 'Amazing Grace', author: 'Newton' }];
+    const chain = makeMockFrom({ data: songs, error: null });
+    const client = { from: vi.fn(() => chain), rpc: vi.fn() };
+
+    await sdSaveSongs(songs, { client });
+
+    expect(client.from).toHaveBeenCalledWith('songs');
+    expect(chain.upsert).toHaveBeenCalled();
+    // Must NOT call delete (sdSaveSongs is additive like storage.save_songs)
+    expect(chain.delete).not.toHaveBeenCalled();
+  });
+
+  it('throws on supabase error during save', async () => {
+    const chain = makeMockFrom({ data: null, error: { message: 'upsert fail' } });
+    const client = { from: vi.fn(() => chain), rpc: vi.fn() };
+
+    await expect(sdSaveSongs([{ title: 'Test' }], { client })).rejects.toThrow('upsert fail');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Settings
+// ---------------------------------------------------------------------------
+
+describe('sdGetSettings', () => {
+  it('queries workspace_settings and returns the settings blob', async () => {
+    const mockRow = { workspace_id: 'ws-1', settings: { pcoToken: 'abc' } };
+    const chain = makeMockFrom({ data: [mockRow], error: null });
+    const client = { from: vi.fn(() => chain), rpc: vi.fn() };
+
+    const result = await sdGetSettings({ client });
+
+    expect(client.from).toHaveBeenCalledWith('workspace_settings');
+    expect(chain.select).toHaveBeenCalled();
+    expect(result).toEqual([mockRow]);
+  });
+
+  it('throws on supabase error', async () => {
+    const chain = makeMockFrom({ data: null, error: { message: 'no row' } });
+    const client = { from: vi.fn(() => chain), rpc: vi.fn() };
+
+    await expect(sdGetSettings({ client })).rejects.toThrow('no row');
+  });
+});
+
+describe('sdSaveSettings', () => {
+  it('upserts into workspace_settings with the settings blob', async () => {
+    const settings = { pcoToken: 'tok-123', typeFormats: {} };
+    const chain = makeMockFrom({ data: [{ settings }], error: null });
+    const client = { from: vi.fn(() => chain), rpc: vi.fn() };
+
+    const result = await sdSaveSettings(settings, { client });
+
+    expect(client.from).toHaveBeenCalledWith('workspace_settings');
+    expect(chain.upsert).toHaveBeenCalled();
+    const upsertArg = chain.upsert.mock.calls[0][0];
+    expect(upsertArg).toMatchObject({ settings });
+    expect(result).toEqual([{ settings }]);
+  });
+
+  it('throws on supabase error during save', async () => {
+    const chain = makeMockFrom({ data: null, error: { message: 'forbidden' } });
+    const client = { from: vi.fn(() => chain), rpc: vi.fn() };
+
+    await expect(sdSaveSettings({}, { client })).rejects.toThrow('forbidden');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Workspace members
+// ---------------------------------------------------------------------------
+
+describe('sdGetMembers', () => {
+  it('queries workspace_members with profiles join', async () => {
+    const mockMembers = [
+      { user_id: 'user-1', role: 'owner', profiles: { display_name: 'Alice', email: 'alice@example.com' } },
+    ];
+    const chain = makeMockFrom({ data: mockMembers, error: null });
+    const client = { from: vi.fn(() => chain), rpc: vi.fn() };
+
+    const result = await sdGetMembers({ client });
+
+    expect(client.from).toHaveBeenCalledWith('workspace_members');
+    expect(chain.select).toHaveBeenCalledWith(expect.stringContaining('profiles'));
+    expect(result).toEqual(mockMembers);
+  });
+
+  it('throws on supabase error', async () => {
+    const chain = makeMockFrom({ data: null, error: { message: 'rls reject' } });
+    const client = { from: vi.fn(() => chain), rpc: vi.fn() };
+
+    await expect(sdGetMembers({ client })).rejects.toThrow('rls reject');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Presence
+// ---------------------------------------------------------------------------
+
+describe('sdGetPresence', () => {
+  it('queries workspace_presences filtered by project_id', async () => {
+    const mockPresence = [
+      { user_id: 'user-1', display_name: 'Alice', last_seen_at: '2026-06-06T12:00:00Z' },
+    ];
+    const chain = makeMockFrom({ data: mockPresence, error: null });
+    const client = { from: vi.fn(() => chain), rpc: vi.fn() };
+
+    const result = await sdGetPresence('proj_abc', { client });
+
+    expect(client.from).toHaveBeenCalledWith('workspace_presences');
+    expect(chain.select).toHaveBeenCalled();
+    expect(chain.eq).toHaveBeenCalledWith('project_id', 'proj_abc');
+    expect(result).toEqual(mockPresence);
+  });
+
+  it('throws on supabase error', async () => {
+    const chain = makeMockFrom({ data: null, error: { message: 'not member' } });
+    const client = { from: vi.fn(() => chain), rpc: vi.fn() };
+
+    await expect(sdGetPresence('proj_abc', { client })).rejects.toThrow('not member');
+  });
+});
+
+describe('sdPostPresenceHeartbeat', () => {
+  it('upserts a presence row for the given project_id', async () => {
+    const chain = makeMockFrom({ data: null, error: null });
+    const client = { from: vi.fn(() => chain), rpc: vi.fn() };
+
+    await sdPostPresenceHeartbeat('proj_abc', { client });
+
+    expect(client.from).toHaveBeenCalledWith('workspace_presences');
+    expect(chain.upsert).toHaveBeenCalled();
+    const upsertArg = chain.upsert.mock.calls[0][0];
+    expect(upsertArg).toMatchObject({ project_id: 'proj_abc' });
+  });
+
+  it('throws on supabase error', async () => {
+    const chain = makeMockFrom({ data: null, error: { message: 'upsert fail' } });
+    const client = { from: vi.fn(() => chain), rpc: vi.fn() };
+
+    await expect(sdPostPresenceHeartbeat('proj_abc', { client })).rejects.toThrow('upsert fail');
+  });
+});
+
+describe('sdDeletePresence', () => {
+  it('deletes workspace_presences for the current user', async () => {
+    const chain = makeMockFrom({ data: null, error: null });
+    // The function deletes by user_id which it resolves from the Supabase session.
+    // We pass userId directly via the opts to avoid needing auth context in tests.
+    const client = { from: vi.fn(() => chain), rpc: vi.fn() };
+
+    await sdDeletePresence({ client, userId: 'user-test-1' });
+
+    expect(client.from).toHaveBeenCalledWith('workspace_presences');
+    expect(chain.delete).toHaveBeenCalled();
+    expect(chain.eq).toHaveBeenCalledWith('user_id', 'user-test-1');
+  });
+
+  it('throws on supabase error', async () => {
+    const chain = makeMockFrom({ data: null, error: { message: 'delete fail' } });
+    const client = { from: vi.fn(() => chain), rpc: vi.fn() };
+
+    await expect(sdDeletePresence({ client, userId: 'user-1' })).rejects.toThrow('delete fail');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Templates
+// ---------------------------------------------------------------------------
+
+describe('sdGetTemplates', () => {
+  it('queries the templates table ordered by is_default desc, name asc', async () => {
+    const mockTemplates = [
+      { id: 'tpl-1', name: 'Default', template_data: {}, is_default: true },
+    ];
+    const chain = makeMockFrom({ data: mockTemplates, error: null });
+    const client = { from: vi.fn(() => chain), rpc: vi.fn() };
+
+    const result = await sdGetTemplates({ client });
+
+    expect(client.from).toHaveBeenCalledWith('templates');
+    expect(chain.select).toHaveBeenCalled();
+    expect(chain.order).toHaveBeenCalled();
+    expect(result).toEqual(mockTemplates);
+  });
+
+  it('throws on supabase error', async () => {
+    const chain = makeMockFrom({ data: null, error: { message: 'access denied' } });
+    const client = { from: vi.fn(() => chain), rpc: vi.fn() };
+
+    await expect(sdGetTemplates({ client })).rejects.toThrow('access denied');
+  });
+});
+
+describe('sdSaveTemplates', () => {
+  it('upserts non-default templates only (skips built-ins)', async () => {
+    const templates = [
+      { id: 'tpl-1', name: 'My Template', template_data: {}, is_default: false },
+      { id: 'tpl-default', name: 'Classic', template_data: {}, is_default: true },
+    ];
+    const chain = makeMockFrom({ data: templates, error: null });
+    const client = { from: vi.fn(() => chain), rpc: vi.fn() };
+
+    await sdSaveTemplates(templates, { client });
+
+    expect(client.from).toHaveBeenCalledWith('templates');
+    expect(chain.upsert).toHaveBeenCalled();
+    // The upserted array must NOT include the default template
+    const upsertArg = chain.upsert.mock.calls[0][0];
+    expect(upsertArg.some(t => t.id === 'tpl-default')).toBe(false);
+    expect(upsertArg.some(t => t.id === 'tpl-1')).toBe(true);
+  });
+
+  it('throws on supabase error during save', async () => {
+    const chain = makeMockFrom({ data: null, error: { message: 'upsert fail' } });
+    const client = { from: vi.fn(() => chain), rpc: vi.fn() };
+
+    await expect(sdSaveTemplates([{ id: 'x', name: 'T', is_default: false }], { client })).rejects.toThrow('upsert fail');
+  });
+});


### PR DESCRIPTION
## Sub-issue 277-C of #277 (stop bundling DATABASE_URL)

Adds the renderer-side data-access module that lets the desktop app do all CRUD directly via supabase-js + the publishable/anon key (RLS-enforced), replacing the sidecar's psycopg path. **Module + unit tests only** — wiring into call sites behind an `IS_ELECTRON` guard is 277-D.

### Change
- New `src/js/supabase-data.js`: 19 functions (`sdGetProjects`, `sdSaveProject`, `sdDeleteProject`, `sdTransferProject` → `rpc('transfer_project_owner')`, announcements/songs/settings/templates/presence/members/history/restore). Dependency-injection (`{ client }`) for testability; browser path resolves the client via `auth-ui.js` `_getSupabaseClient()`. Each function throws on the supabase `{data,error}` error channel.
- New `tests/supabase-data.spec.js`: 38 vitest unit tests with a mock chainable client (red→green TDD).
- `docs/ai/contracts/issue-277-C.json`.

### Limitations flagged for 277-D (in contract `not_tested` + the 277-D task)
revision auto-increment on update · announcements full-replace (server does DELETE+INSERT; module upserts) · presence 90s TTL filter · restore CAS · session-supplied `workspaceId`/`userId`. 277-D must resolve these when wiring.

### Verification
- `node --check` ✓ · `npm test` → 107 passed (38 new + 69 existing), 1 skipped ✓ · vite build clean ✓.
- No UI/Electron-specific APIs; real packaged data-flow is exercised by 277-D + its manual Electron smoke.

**Do not merge** — manual review. Draft. (Depends on 277-B's RPC being deployed for live `sdTransferProject`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)