### PR TITLE
test(rls): #277-E RLS suite runs in CI + cross-tenant write isolation

### DIFF
--- a/docs/ai/contracts/issue-277-E.json
+++ b/docs/ai/contracts/issue-277-E.json
@@ -1,0 +1,48 @@
+{
+  "issue": "277-E",
+  "generated": "2026-06-06",
+  "criteria": [
+    {
+      "criterion_id": "issue-277-E-c1",
+      "text": "The RLS isolation suite actually RUNS in CI: test_rls_isolation.py carries the `integration` marker so the db-integration job's `-m integration` filter selects it (previously all 25 tests were silently deselected).",
+      "mode": "integration",
+      "test_file": "tests/test_rls_isolation.py",
+      "test_id": "pytestmark integration + db-integration job",
+      "status": "pass"
+    },
+    {
+      "criterion_id": "issue-277-E-c2",
+      "text": "A workspace-A user cannot SELECT another workspace's rows (projects/project_revisions/workspace_settings/announcements/songs/templates/fonts) — returns 0 rows.",
+      "mode": "integration",
+      "test_file": "tests/test_rls_isolation.py",
+      "test_id": "test_cross_tenant_select_blocked",
+      "status": "pass"
+    },
+    {
+      "criterion_id": "issue-277-E-c3",
+      "text": "A workspace-A user cannot INSERT into another workspace (WITH CHECK rejects → InsufficientPrivilege).",
+      "mode": "integration",
+      "test_file": "tests/test_rls_isolation.py",
+      "test_id": "test_cross_tenant_insert_blocked",
+      "status": "pass"
+    },
+    {
+      "criterion_id": "issue-277-E-c4",
+      "text": "A workspace-A user cannot UPDATE another workspace's rows (projects/announcements/songs/templates/workspace_settings) — affects 0 rows.",
+      "mode": "integration",
+      "test_file": "tests/test_rls_isolation.py",
+      "test_id": "test_cross_tenant_update_blocked",
+      "status": "pass"
+    },
+    {
+      "criterion_id": "issue-277-E-c5",
+      "text": "A workspace-A user cannot DELETE another workspace's rows across every workspace table — affects 0 rows; the target rows survive (verified via owner connection).",
+      "mode": "integration",
+      "test_file": "tests/test_rls_isolation.py",
+      "test_id": "test_cross_tenant_delete_blocked",
+      "status": "pass"
+    }
+  ],
+  "stack": "python",
+  "not_tested": []
+}

--- a/tests/test_rls_isolation.py
+++ b/tests/test_rls_isolation.py
@@ -28,10 +28,17 @@ import pytest
 
 DATABASE_URL = os.environ.get("DATABASE_URL", "").strip()
 
-pytestmark = pytest.mark.skipif(
-    not DATABASE_URL,
-    reason="DATABASE_URL not set; RLS isolation tests require a live Supabase project",
-)
+# NOTE: the `integration` marker is REQUIRED. The CI db-integration job runs
+# `pytest ... -m integration`, so without it this entire security-critical suite
+# was silently DESELECTED in CI (it collected but never ran — issue #277-E). Keep
+# both marks: integration (so CI runs it) + skipif (so a no-DB run stays green).
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not DATABASE_URL,
+        reason="DATABASE_URL not set; RLS isolation tests require a live Supabase project",
+    ),
+]
 
 # Unique per-test-data marker so seed rows are recognizable and cleanup is total,
 # even if a previous run crashed before teardown.
@@ -334,3 +341,48 @@ class TestRLSIsolation:
                     "user_a must not be able to update user_b's project "
                     "(non-member of workspace_b — RLS USING silently returns 0 rows)"
                 )
+
+    # ── cross-tenant DELETE must affect 0 rows across every table (#277-E) ────
+    # The RLS USING clause filters workspace_b rows out of user_a's view, so a
+    # DELETE scoped to workspace_b matches nothing. (project_revisions has no
+    # delete policy at all — append-only — so it is likewise 0.)
+    @pytest.mark.parametrize("table", WORKSPACE_TABLES)
+    def test_cross_tenant_delete_blocked(self, table):
+        c = self.ctx
+        with _as_user(c["user_a"]) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"delete from public.{table} where workspace_id = %s", [c["ws_b"]]
+                )
+                assert cur.rowcount == 0, f"user_a must not delete workspace_b {table}"
+        # sanity: the workspace_b row still exists (seen via the owner connection)
+        with _service_conn() as svc:
+            with svc.cursor() as scur:
+                scur.execute(
+                    f"select count(*) from public.{table} where workspace_id = %s", [c["ws_b"]]
+                )
+                assert scur.fetchone()[0] >= 1, f"workspace_b {table} row must survive"
+
+    # ── cross-tenant UPDATE must affect 0 rows on writable tables (#277-E) ────
+    # Mirrors the projects non-owner case across the other workspace tables that
+    # carry a freely-updatable text column. RLS USING filters workspace_b rows
+    # out of user_a's view, so the UPDATE matches nothing.
+    @pytest.mark.parametrize(
+        "table,assign",
+        [
+            ("projects", "name = 'x_should_not_update'"),
+            ("announcements", "title = 'x_should_not_update'"),
+            ("songs", "title = 'x_should_not_update'"),
+            ("templates", "name = 'x_should_not_update'"),
+            ("workspace_settings", "settings = '{\"x\":1}'"),
+        ],
+    )
+    def test_cross_tenant_update_blocked(self, table, assign):
+        c = self.ctx
+        with _as_user(c["user_a"]) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"update public.{table} set {assign} where workspace_id = %s",
+                    [c["ws_b"]],
+                )
+                assert cur.rowcount == 0, f"user_a must not update workspace_b {table}"


### PR DESCRIPTION
## Sub-issue 277-E of #277 (stop bundling DATABASE_URL)

Delivers the "negative tests prove isolation" acceptance — and fixes a latent gate gap found while doing so.

### Gate gap fixed
`tests/test_rls_isolation.py` (25 cross-tenant tests) carried only a `skipif(no DATABASE_URL)` mark — **no `integration` marker**. The CI `db-integration` job runs `pytest ... -m integration`, which therefore **deselected the entire suite** (collected, never ran). The workspace-isolation boundary #277 depends on was unguarded in CI. Added the `integration` marker (kept alongside `skipif`).

### New write-isolation tests
- `test_cross_tenant_update_blocked` (projects/announcements/songs/templates/workspace_settings) → 0 rows.
- `test_cross_tenant_delete_blocked` (every workspace table) → 0 rows, and the target row survives (verified via the owner connection).

These complement the existing SELECT-blocked and INSERT-blocked coverage, giving full SELECT/INSERT/UPDATE/DELETE cross-tenant negative coverage.

### Verification
- Live against the staging/prod Supabase project: `pytest -m integration` → **37 passed** (25 existing + 12 new); all writes rolled back.
- `ai-workflow checks --level pr` → 108 pytest, 69 vitest, vite build ✓ (integration tests auto-skip with no DB locally).

**Do not merge** — manual review. Draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)