### PR TITLE
fix(collab): #216 snapshot project_revisions on every save + unique revision index

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           python-version: '3.11'
       - run: python -m pip install --upgrade pip pytest
-      - run: pytest tests/test_server_utils.py tests/test_update.py tests/test_drive.py tests/test_propresenter_export.py
+      - run: pytest tests/test_server_utils.py tests/test_update.py tests/test_drive.py tests/test_propresenter_export.py tests/test_revision_snapshots.py
 
   db-integration:
     # Only run on the canonical repo so forks without the required secrets
@@ -47,4 +47,4 @@ jobs:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           SUPABASE_JWT_SECRET: ${{ secrets.SUPABASE_JWT_SECRET }}
           APP_MODE: server
-        run: pytest tests/test_migrations.py tests/test_rls_isolation.py tests/test_db.py -m integration -q
+        run: pytest tests/test_migrations.py tests/test_rls_isolation.py tests/test_db.py tests/test_revision_unique_constraint.py -m integration -q

--- a/docs/ai/contracts/issue-216.json
+++ b/docs/ai/contracts/issue-216.json
@@ -1,0 +1,47 @@
+{
+  "issue": "216",
+  "generated": "2026-06-06",
+  "criteria": [
+    {
+      "criterion_id": "issue-216-c1",
+      "text": "Every successful project save (not just the /restore path) appends exactly one project_revisions row.",
+      "mode": "unit",
+      "test_file": "tests/test_revision_snapshots.py",
+      "test_id": "TestSaveProjectRevisionSnapshot::test_issue_216_c1_snapshot_inserted_exactly_once_per_save",
+      "status": "pass"
+    },
+    {
+      "criterion_id": "issue-216-c2",
+      "text": "The snapshot uses the freshly-incremented revision (revision_number = the RETURNING revision), so revision numbers are unique per project.",
+      "mode": "unit",
+      "test_file": "tests/test_revision_snapshots.py",
+      "test_id": "TestSaveProjectRevisionSnapshot::test_issue_216_c2_snapshot_uses_new_incremented_revision",
+      "status": "pass"
+    },
+    {
+      "criterion_id": "issue-216-c3",
+      "text": "The snapshot row carries all required fields (snap_id uuid, project_id, revision_number, state, summary) so it can restore a previous version.",
+      "mode": "unit",
+      "test_file": "tests/test_revision_snapshots.py",
+      "test_id": "TestSaveProjectRevisionSnapshot::test_issue_216_c3_snapshot_has_required_fields",
+      "status": "pass"
+    },
+    {
+      "criterion_id": "issue-216-c4",
+      "text": "Revision numbers are unique per project at the DB level: a duplicate (project_id, revision_number) is rejected by a unique index.",
+      "mode": "integration",
+      "test_file": "tests/test_revision_unique_constraint.py",
+      "test_id": "test_issue_216_c5_duplicate_revision_rejected",
+      "status": "pass"
+    },
+    {
+      "criterion_id": "issue-216-c5",
+      "text": "Electron-mode (renderer/supabase-js) saves also snapshot history. Implemented server-side here (PostgresStorageBackend.save_project); the renderer path (277-C/D) needs a matching project_revisions insert in supabase-data.js sdSaveProject.",
+      "mode": "manual",
+      "status": "UNVERIFIED",
+      "reason": "Renderer-side snapshot belongs on the unmerged 277-C/D stack; this PR fixes the server-mode regression. Approach changed from a DB trigger to application-level because a trigger cannot run revisions.generate_summary (Python), cannot be deployed by the agent (gated), and removing the app-level snapshot before deploy would create a live-regression window. The unique-index migration (c4) ALSO needs a live supabase db push (human-authorized, like 277-B). See decisions.md 2026-06-06."
+    }
+  ],
+  "stack": "python",
+  "not_tested": ["issue-216-c5"]
+}

--- a/docs/ai/decisions.md
+++ b/docs/ai/decisions.md
@@ -4,6 +4,23 @@ Append-only log of architecture / workflow decisions worth preserving across ses
 
 ---
 
+## 2026-06-06 — #216 revision snapshots: application-level, not a DB trigger
+
+**Context.** #216 requires appending a `project_revisions` snapshot on every successful save (regression: only the `/restore` path snapshotted). The initial plan (and the 277-D deferral note) assumed a DB trigger so it would cover both the server (psycopg) and renderer (supabase-js) write paths uniformly.
+
+**Decision.** Implement it **application-level** in `PostgresStorageBackend.save_project` (mirroring `save_project_transactional`), plus a unique index on `project_revisions (project_id, revision_number)`. A DB trigger was rejected for three reasons:
+1. **Summary.** `project_revisions.summary` is a stored column produced by `revisions.generate_summary` (Python). A trigger can't run that, so a trigger-based snapshot would lose the #217 summaries (or require porting 176 lines of diff logic to plpgsql).
+2. **Deploy gate.** The `supabase/migrations` track isn't applied by CI and the agent is (correctly) blocked from a direct live apply — so a trigger couldn't be verified live by the agent.
+3. **Live-regression window.** Removing the existing app-level `/restore` snapshot in favor of an undeployed trigger would stop snapshots in production until the trigger is deployed.
+
+**Consequences.**
+- `save_project` now does a 4-statement sequence (SELECT prev state → upsert RETURNING → profiles enrich → INSERT project_revisions), matching the transactional path. Existing `save_project` mocks (`test_project_metadata`, `test_storage_assets`) were updated for the new sequence.
+- A unique index migration (`20260606000002_project_revisions_unique_revision.sql`) hard-enforces "unique revision numbers per project" (verified: zero existing dupes). Needs a live `supabase db push` (human-authorized, like 277-B).
+- **Renderer (electron) path still needs its own snapshot.** Electron saves go renderer→Supabase, bypassing `save_project`, so they won't snapshot until `supabase-data.js` `sdSaveProject` (277-C/D) inserts a `project_revisions` row. Tracked as a follow-up on the #277 stack.
+- Also wired the previously-orphaned `tests/test_revision_snapshots.py` into the CI `python` job (it ran nowhere before).
+
+---
+
 ## 2026-06-05 — Presence project_id is TEXT, not uuid (fix forward migration, not edit-in-place)
 
 **Context.** `workspace_presences.project_id` was declared `uuid` in `20260603000003_workspace_presences.sql`, but project ids are application-generated TEXT (`proj_<timestamp>_<rand>`) and `public.projects.id` is `text`. Every presence read/heartbeat 500'd with `InvalidTextRepresentation`; the frontend's best-effort error swallowing hid it.

--- a/scripts/run_ai_workflow.py
+++ b/scripts/run_ai_workflow.py
@@ -30,6 +30,7 @@ CI_PYTEST_TARGETS = [
     "tests/test_update.py",
     "tests/test_drive.py",
     "tests/test_propresenter_export.py",
+    "tests/test_revision_snapshots.py",
 ]
 
 MANUAL_SMOKE_DOC = "docs/testing/manual-smoke.md"

--- a/storage.py
+++ b/storage.py
@@ -608,6 +608,9 @@ class PostgresStorageBackend(StorageBackend):
             raise ValueError("project data must contain an 'id' key")
 
         import json as _json  # noqa: PLC0415
+        import uuid as _uuid  # noqa: PLC0415
+        from db import from_jsonb  # noqa: PLC0415
+        from revisions import generate_summary  # noqa: PLC0415
 
         project_id = data["id"]
 
@@ -622,6 +625,23 @@ class PostgresStorageBackend(StorageBackend):
         created_at = data.get("createdAt") or None
 
         with self._transaction() as conn:
+            # #216: capture the prior state BEFORE the upsert so we can generate a
+            # meaningful revision summary (None for a brand-new project).
+            prev_ws_clause = ""
+            prev_params: dict = {"id": project_id}
+            if self.workspace_id is not None:
+                prev_ws_clause = "AND workspace_id = %(workspace_id)s::uuid"
+                prev_params["workspace_id"] = self.workspace_id
+            prev_cursor = conn.execute(
+                f"SELECT state FROM projects WHERE id = %(id)s {prev_ws_clause}",
+                prev_params,
+            )
+            prev_row = prev_cursor.fetchone()
+            prev_state = None
+            if prev_row is not None:
+                _prev = from_jsonb(prev_row[0])
+                prev_state = _prev if isinstance(_prev, dict) else None
+
             cursor = conn.execute(
                 """
                 INSERT INTO projects (
@@ -660,7 +680,35 @@ class PostgresStorageBackend(StorageBackend):
             raw_cols = [d[0] for d in cursor.description]
             raw = dict(zip(raw_cols, row))
             # JOIN profiles to get attribution emails for the returned dict.
-            return _pg_enrich_project_row(conn, raw)
+            saved = _pg_enrich_project_row(conn, raw)
+
+            # #216: append a revision snapshot on EVERY successful save (regression
+            # fix — previously only save_project_transactional / the /restore path
+            # snapshotted). One row per save; revision_number is the freshly
+            # incremented revision, so it is unique per project. Mirrors the
+            # /restore snapshot shape (append-only project_revisions table).
+            conn.execute(
+                """
+                INSERT INTO project_revisions (
+                    id, project_id, workspace_id, revision_number, state,
+                    created_at, created_by_user_id, summary
+                ) VALUES (
+                    %(snap_id)s::uuid, %(project_id)s, %(workspace_id)s::uuid,
+                    %(revision_number)s, %(state)s::jsonb, NOW(),
+                    %(created_by_user_id)s::uuid, %(summary)s
+                )
+                """,
+                {
+                    "snap_id": str(_uuid.uuid4()),
+                    "project_id": project_id,
+                    "workspace_id": self.workspace_id,
+                    "revision_number": saved["revision"],
+                    "state": state_json,
+                    "created_by_user_id": updated_by_user_id,
+                    "summary": generate_summary(prev_state, data),
+                },
+            )
+            return saved
 
     def save_project_transactional(
         self,

--- a/supabase/migrations/20260606000002_project_revisions_unique_revision.sql
+++ b/supabase/migrations/20260606000002_project_revisions_unique_revision.sql
@@ -1,0 +1,14 @@
+-- Migration: project_revisions_unique_revision
+-- Issue #216. Enforce "revision numbers are unique per project" at the database
+-- level. Previously uniqueness relied solely on application logic (revision is
+-- incremented on each save). A unique index makes a duplicate (project_id,
+-- revision_number) impossible regardless of the write path (server psycopg or
+-- the renderer's supabase-js), which also hard-guards against any double-snapshot
+-- bug (e.g. both save_project and a future trigger inserting the same revision).
+--
+-- Safe + idempotent: verified there are zero existing duplicate
+-- (project_id, revision_number) pairs before adding this; CREATE UNIQUE INDEX
+-- IF NOT EXISTS is a no-op on re-apply.
+
+create unique index if not exists project_revisions_project_revision_uniq
+  on public.project_revisions (project_id, revision_number);

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -202,10 +202,17 @@ class TestPgRowToProject:
 def _make_pg_save_mock(returned_row: dict):
     """Return a mock (transaction, conn) for save_project().
 
-    save_project() calls _pg_enrich_project_row() after RETURNING, which
-    issues a second conn.execute() to fetch profiles.  We return two cursors:
-    the first for the INSERT RETURNING, the second (profiles) returns no rows.
+    Since #216, save_project() issues four conn.execute() calls in order:
+      1. SELECT state           — prev state for the revision summary
+      2. INSERT ... RETURNING    — the upsert (params asserted by these tests)
+      3. SELECT profiles         — _pg_enrich_project_row() attribution lookup
+      4. INSERT project_revisions — the #216 revision snapshot
     """
+    prev_cursor = MagicMock()
+    prev_cursor.fetchone.return_value = (
+        json.dumps({"id": returned_row.get("id"), "name": "prev"}),
+    )
+
     mock_returning_cursor = MagicMock()
     mock_returning_cursor.fetchone.return_value = tuple(returned_row.values())
     mock_returning_cursor.description = [(col, None) for col in returned_row.keys()]
@@ -213,8 +220,12 @@ def _make_pg_save_mock(returned_row: dict):
     mock_profiles_cursor = MagicMock()
     mock_profiles_cursor.fetchall.return_value = []  # no profiles rows in test
 
+    snapshot_cursor = MagicMock()
+
     mock_conn = MagicMock()
-    mock_conn.execute.side_effect = [mock_returning_cursor, mock_profiles_cursor]
+    mock_conn.execute.side_effect = [
+        prev_cursor, mock_returning_cursor, mock_profiles_cursor, snapshot_cursor,
+    ]
 
     from contextlib import contextmanager
 
@@ -269,8 +280,9 @@ class TestPostgresSaveProjectAttribution:
             kwargs = extra_kwargs or {}
             backend.save_project({"id": project_id, "name": "Test"}, **kwargs)
 
-        # Extract the params dict passed to the first conn.execute() (INSERT RETURNING).
-        call_args = mock_conn.execute.call_args_list[0]
+        # Extract the params dict passed to the upsert (INSERT ... RETURNING).
+        # Since #216 the prev-state SELECT is call index 0, so the upsert is index 1.
+        call_args = mock_conn.execute.call_args_list[1]
         return call_args[0][1]  # positional arg 1 = params dict
 
     def test_updated_by_user_id_from_kwarg(self):

--- a/tests/test_revision_snapshots.py
+++ b/tests/test_revision_snapshots.py
@@ -324,6 +324,71 @@ class TestSaveProjectTransactionalRevisionSnapshot:
 
 
 # =============================================================================
+# save_project — revision snapshot on EVERY save (issue #216)
+# =============================================================================
+
+class TestSaveProjectRevisionSnapshot:
+    """#216: a normal save_project() (not just /restore) must append exactly one
+    project_revisions row using the freshly-incremented revision.
+
+    save_project() issues the same 4-call execute() sequence as
+    save_project_transactional(): SELECT prev state, INSERT upsert RETURNING,
+    SELECT profiles (enrichment), INSERT project_revisions — so _make_conn_for_save
+    is reused.
+    """
+
+    _PROJECT_ID = str(uuid.uuid4())
+
+    def test_issue_216_c1_snapshot_inserted_exactly_once_per_save(self):
+        from storage import PostgresStorageBackend
+
+        project_data = {"id": self._PROJECT_ID, "name": "Sunday Service"}
+        project_row = _pg_project_row(self._PROJECT_ID, revision=2)
+        conn = _make_conn_for_save(project_row)
+
+        backend = PostgresStorageBackend()
+        with patch("db.transaction", lambda claims=None: _fake_tx(conn)):
+            backend.save_project(project_data, updated_by_user_id=None)
+
+        # 4 execute calls; the last is the project_revisions snapshot INSERT.
+        assert conn.execute.call_count == 4
+        snapshot_sql = conn.execute.call_args_list[3][0][0]
+        assert "project_revisions" in snapshot_sql
+
+    def test_issue_216_c2_snapshot_uses_new_incremented_revision(self):
+        from storage import PostgresStorageBackend
+
+        project_data = {"id": self._PROJECT_ID, "name": "Sunday Service"}
+        project_row = _pg_project_row(self._PROJECT_ID, revision=7)
+        conn = _make_conn_for_save(project_row)
+
+        backend = PostgresStorageBackend()
+        with patch("db.transaction", lambda claims=None: _fake_tx(conn)):
+            backend.save_project(project_data, updated_by_user_id=None)
+
+        params = conn.execute.call_args_list[3][0][1]
+        assert params["revision_number"] == 7  # the RETURNING revision, not the client's
+
+    def test_issue_216_c3_snapshot_has_required_fields(self):
+        from storage import PostgresStorageBackend
+
+        project_data = {"id": self._PROJECT_ID, "name": "Sunday Service"}
+        project_row = _pg_project_row(self._PROJECT_ID, revision=2)
+        conn = _make_conn_for_save(project_row)
+
+        backend = PostgresStorageBackend()
+        with patch("db.transaction", lambda claims=None: _fake_tx(conn)):
+            backend.save_project(project_data, updated_by_user_id=None)
+
+        params = conn.execute.call_args_list[3][0][1]
+        for key in ("snap_id", "project_id", "revision_number", "state", "summary"):
+            assert key in params, f"snapshot params missing {key}"
+        assert params["project_id"] == self._PROJECT_ID
+        # snap_id must be a valid UUID
+        uuid.UUID(params["snap_id"])
+
+
+# =============================================================================
 # get_project_revisions
 # =============================================================================
 

--- a/tests/test_revision_unique_constraint.py
+++ b/tests/test_revision_unique_constraint.py
@@ -1,0 +1,98 @@
+"""test_revision_unique_constraint.py — contract test for issue #216 (uniqueness).
+
+Proves the project_revisions unique index
+(migration 20260606000002_project_revisions_unique_revision.sql) rejects a
+duplicate (project_id, revision_number) — i.e. "revision numbers are unique per
+project" is enforced at the DB level, not just by application logic.
+
+Self-contained + non-destructive: applies the migration in a transaction, seeds
+a workspace + project + one revision, attempts a duplicate revision insert
+(expects a unique violation), and ROLLS BACK. No persisted change. The live
+`supabase db push` of this migration is a separate human-authorized step.
+
+Run: DATABASE_URL=<pooler> APP_MODE=server pytest tests/test_revision_unique_constraint.py -m integration -v
+"""
+
+import os
+import pathlib
+import uuid
+
+import pytest
+
+DATABASE_URL = os.environ.get("DATABASE_URL", "").strip()
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not DATABASE_URL,
+        reason="DATABASE_URL not set; unique-constraint test requires a live Supabase project",
+    ),
+]
+
+_MIGRATION = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / "supabase"
+    / "migrations"
+    / "20260606000002_project_revisions_unique_revision.sql"
+)
+
+
+@pytest.fixture
+def conn():
+    import psycopg
+
+    c = psycopg.connect(DATABASE_URL)  # transactional
+    try:
+        yield c
+    finally:
+        c.rollback()
+        c.close()
+
+
+def test_issue_216_c5_duplicate_revision_rejected(conn):
+    """issue-216-c5: a second project_revisions row with the same
+    (project_id, revision_number) raises a unique violation."""
+    import psycopg
+
+    with conn.cursor() as cur:
+        cur.execute(_MIGRATION.read_text(encoding="utf-8"))
+
+        tag = uuid.uuid4().hex
+        cur.execute(
+            """
+            insert into auth.users (instance_id, id, aud, role, email)
+            values ('00000000-0000-0000-0000-000000000000',
+                    gen_random_uuid(), 'authenticated', 'authenticated', %s)
+            returning id
+            """,
+            [f"rev_uniq_{tag}@test.invalid"],
+        )
+        user_id = cur.fetchone()[0]
+        cur.execute(
+            "insert into public.workspaces (id, name) values (gen_random_uuid(), %s) returning id",
+            [f"rev_uniq_ws_{tag}"],
+        )
+        ws = cur.fetchone()[0]
+        cur.execute(
+            "insert into public.workspace_members (workspace_id, user_id, role) values (%s, %s, 'owner')",
+            [ws, user_id],
+        )
+        proj = f"proj_revuniq_{tag}"
+        cur.execute(
+            "insert into public.projects (id, workspace_id, name, owner_user_id) values (%s, %s, 'seed', %s)",
+            [proj, ws, user_id],
+        )
+
+        def _insert_rev(rev):
+            cur.execute(
+                """
+                insert into public.project_revisions
+                    (id, project_id, workspace_id, revision_number, state, created_by_user_id)
+                values (gen_random_uuid(), %s, %s, %s, '{}'::jsonb, %s)
+                """,
+                [proj, ws, rev, user_id],
+            )
+
+        _insert_rev(1)  # first revision 1 — ok
+        with pytest.raises(psycopg.errors.UniqueViolation):
+            _insert_rev(1)  # duplicate revision 1 — must be rejected

--- a/tests/test_storage_assets.py
+++ b/tests/test_storage_assets.py
@@ -317,20 +317,40 @@ class TestStorageIntegrationWithStoragePy(unittest.TestCase):
         return PostgresStorageBackend(workspace_id=workspace_id)
 
     def _mock_transaction(self):
-        """Return a context-manager mock that yields a fake conn."""
-        conn = MagicMock()
-        cursor = MagicMock()
-        cursor.fetchone.return_value = (
+        """Return a context-manager mock that yields a fake conn.
+
+        Routes conn.execute() by SQL so it is robust to save_project()'s
+        multi-statement sequence (since #216: prev-state SELECT, upsert
+        RETURNING, profiles enrichment, project_revisions snapshot INSERT).
+        """
+        row_cursor = MagicMock()
+        row_cursor.fetchone.return_value = (
             "proj-1", "Test", None, "workspace",
             '{"id":"proj-1","name":"Test"}', 1,
             None, None, None, None, "ws-abc",
         )
-        cursor.description = [
+        row_cursor.description = [
             ("id",), ("name",), ("owner_user_id",), ("visibility",),
             ("state",), ("revision",), ("created_at",), ("updated_at",),
             ("created_by_user_id",), ("updated_by_user_id",), ("workspace_id",),
         ]
-        conn.execute.return_value = cursor
+
+        def _route(sql, params=None):
+            s = " ".join(str(sql).split())
+            if s.startswith("SELECT state FROM projects"):
+                prev = MagicMock()
+                prev.fetchone.return_value = ('{"id":"proj-1","name":"Test"}',)
+                return prev
+            if "INSERT INTO projects" in s:
+                return row_cursor
+            if "profiles" in s:
+                prof = MagicMock()
+                prof.fetchall.return_value = []
+                return prof
+            return MagicMock()  # project_revisions snapshot INSERT, etc.
+
+        conn = MagicMock()
+        conn.execute.side_effect = _route
         ctx = MagicMock()
         ctx.__enter__ = MagicMock(return_value=conn)
         ctx.__exit__ = MagicMock(return_value=False)


### PR DESCRIPTION
## #216 — append a revision snapshot on every save

**Regression fixed:** only the `/restore` path (`save_project_transactional`) appended a `project_revisions` row; normal saves via `save_project` did **not**, so revision history was empty for ordinary edits.

### Change
- `PostgresStorageBackend.save_project` now mirrors the `/restore` path: SELECT prev state → upsert RETURNING → profiles enrich → INSERT `project_revisions` (freshly-incremented revision + `generate_summary()`). One snapshot per successful server-mode save.
- New migration `20260606000002_project_revisions_unique_revision.sql`: unique index on `(project_id, revision_number)` to hard-enforce "unique revision numbers per project" (verified zero existing dupes).
- Wired the previously **orphaned** `tests/test_revision_snapshots.py` into the CI `python` job, and the new live test into `db-integration`.

### Why application-level, not a DB trigger
A trigger can't run the Python `revisions.generate_summary` (loses #217 summaries), can't be deployed by the agent (gated), and removing the app-level snapshot before deploy would create a live-regression window. See `docs/ai/decisions.md` (2026-06-06).

### Tests
- 3 new mocked unit tests (snapshot once / uses new revision / required fields).
- 1 live integration test (duplicate `(project_id, revision_number)` rejected; rolled back) — verified live.
- Updated 8 existing `save_project` mocks for the new 4-statement sequence.
- `ai-workflow checks --level pr` → 138 pytest, 69 vitest, build ✓.

### ⚠️ Notes
- The unique-index migration needs a live `supabase db push` (human-authorized, like 277-B).
- **Renderer/electron-path snapshot is a follow-up** (sdSaveProject in the #277-C/D stack) — those saves bypass server.py.

**Do not merge** — manual review. Draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)