### PR TITLE
feat(pco): auto-add next week's offering line on import/re-sync

### DIFF
--- a/docs/ai/contracts/issue-next-week-offering.json
+++ b/docs/ai/contracts/issue-next-week-offering.json
@@ -82,6 +82,14 @@
       "reason": "Skip paths are exercised by the pure functions (empty cause -> no-op, c7) but the end-to-end skip depends on the live wiring. Pure-function half is covered by c3/c7; the integration half is manual."
     },
     {
+      "criterion_id": "issue-next-week-offering-c12",
+      "text": "boldFirstLine(text) wraps the first non-empty line in markdown bold (**...**), idempotent (no double-bold), preserves the rest of the body, and is a no-op for blank/non-string. Wired into applyPcoData so THIS week's OFFERING charity/cause renders bold like the next-week line, gated by the same opt-next-week-offering toggle.",
+      "mode": "unit",
+      "test_file": "tests/pco-core.spec.js",
+      "test_id": "issue-next-week-offering-c12: bolds the first non-empty line",
+      "status": "pending"
+    },
+    {
       "criterion_id": "issue-next-week-offering-c11",
       "text": "A per-project checkbox 'opt-next-week-offering' exists in the Document Options dropdown, defaults to ON, persists in project state, and when unchecked suppresses the auto-append on import/re-sync.",
       "mode": "manual",

--- a/docs/ai/contracts/issue-next-week-offering.json
+++ b/docs/ai/contracts/issue-next-week-offering.json
@@ -1,0 +1,98 @@
+{
+  "issue": "next-week-offering",
+  "generated": "2026-06-08",
+  "stack": "javascript",
+  "summary": "On PCO import and re-sync, append/replace a 'Next week's offering is for **<cause>**' line on this week's OFFERING section item.detail, where <cause> is the first non-empty line of the NEXT upcoming plan's OFFERING note. Idempotent, best-effort, preserves manual edits, gated per-project by the opt-next-week-offering checkbox (default ON) in Document Options.",
+  "criteria": [
+    {
+      "criterion_id": "issue-next-week-offering-c1",
+      "text": "deriveNextWeekOfferingCause(noteBody) returns the first non-empty line of the note, trimmed (leading blank lines skipped).",
+      "mode": "unit",
+      "test_file": "tests/pco-core.spec.js",
+      "test_id": "issue-next-week-offering-c1: derives first non-empty line",
+      "status": "pending"
+    },
+    {
+      "criterion_id": "issue-next-week-offering-c2",
+      "text": "deriveNextWeekOfferingCause strips surrounding markdown bold markers (e.g. **Faith Promise** -> Faith Promise) from the derived first line.",
+      "mode": "unit",
+      "test_file": "tests/pco-core.spec.js",
+      "test_id": "issue-next-week-offering-c2: strips bold markers",
+      "status": "pending"
+    },
+    {
+      "criterion_id": "issue-next-week-offering-c3",
+      "text": "deriveNextWeekOfferingCause returns '' for blank, whitespace-only, null, or undefined note bodies.",
+      "mode": "unit",
+      "test_file": "tests/pco-core.spec.js",
+      "test_id": "issue-next-week-offering-c3: blank note yields empty cause",
+      "status": "pending"
+    },
+    {
+      "criterion_id": "issue-next-week-offering-c4",
+      "text": "applyNextWeekOfferingLine(detail, cause) appends \"Next week's offering is for **<cause>**\" on its own line at the end when no such line exists.",
+      "mode": "unit",
+      "test_file": "tests/pco-core.spec.js",
+      "test_id": "issue-next-week-offering-c4: appends line when absent",
+      "status": "pending"
+    },
+    {
+      "criterion_id": "issue-next-week-offering-c5",
+      "text": "applyNextWeekOfferingLine is idempotent: re-running with the same cause does not duplicate the line; running with a new cause replaces the existing 'Next week's offering is for ...' line in place.",
+      "mode": "unit",
+      "test_file": "tests/pco-core.spec.js",
+      "test_id": "issue-next-week-offering-c5: idempotent replace, never duplicates",
+      "status": "pending"
+    },
+    {
+      "criterion_id": "issue-next-week-offering-c6",
+      "text": "applyNextWeekOfferingLine preserves the existing offering body text above the managed trailing line (manual edits are not clobbered).",
+      "mode": "unit",
+      "test_file": "tests/pco-core.spec.js",
+      "test_id": "issue-next-week-offering-c6: preserves existing body",
+      "status": "pending"
+    },
+    {
+      "criterion_id": "issue-next-week-offering-c7",
+      "text": "applyNextWeekOfferingLine(detail, '') (empty/falsy cause) returns the detail unchanged and removes any previously-managed next-week line (no dangling 'for ****').",
+      "mode": "unit",
+      "test_file": "tests/pco-core.spec.js",
+      "test_id": "issue-next-week-offering-c7: empty cause is a no-op / clears stale line",
+      "status": "pending"
+    },
+    {
+      "criterion_id": "issue-next-week-offering-c8",
+      "text": "On import and on re-sync, the wiring fetches the next upcoming plan (first plan with sort_date > current) and its notes, derives the cause from the OFFERING-category note, and applies it to this week's OFFERING section item.detail; the line appears exactly once after a re-sync.",
+      "mode": "manual",
+      "status": "UNVERIFIED",
+      "reason": "Requires live PCO OAuth + a real plan whose next week has an OFFERING note; the import/resync wiring touches the DOM, network (pcoGet), and global items[] with no unit seam. Manual smoke: import a plan, confirm line appears once; re-sync, confirm no duplicate."
+    },
+    {
+      "criterion_id": "issue-next-week-offering-c9",
+      "text": "Any failure fetching the next plan or its notes is swallowed and does NOT break the import (mirrors the best-effort try/catch in pcoFetchAndApplyServing).",
+      "mode": "manual",
+      "status": "UNVERIFIED",
+      "reason": "Best-effort network failure path; no unit seam around pcoGet in the import flow. Manual/inspection: induce a network failure on the next-plan fetch and confirm the import still completes."
+    },
+    {
+      "criterion_id": "issue-next-week-offering-c10",
+      "text": "No next plan, no next-OFFERING note, or no OFFERING item in this week's plan -> the feature silently skips (no line added, no error).",
+      "mode": "manual",
+      "status": "UNVERIFIED",
+      "reason": "Skip paths are exercised by the pure functions (empty cause -> no-op, c7) but the end-to-end skip depends on the live wiring. Pure-function half is covered by c3/c7; the integration half is manual."
+    },
+    {
+      "criterion_id": "issue-next-week-offering-c11",
+      "text": "A per-project checkbox 'opt-next-week-offering' exists in the Document Options dropdown, defaults to ON, persists in project state, and when unchecked suppresses the auto-append on import/re-sync.",
+      "mode": "manual",
+      "status": "UNVERIFIED",
+      "reason": "DOM checkbox + project-state persistence + gating, following the existing opt-* pattern (state.js ref, projects.js collect/apply default !== false, formatting.js re-render). No JS module seam; manual smoke confirms presence, default-on, persistence, and gate behavior."
+    }
+  ],
+  "not_tested": [
+    "issue-next-week-offering-c8",
+    "issue-next-week-offering-c9",
+    "issue-next-week-offering-c10",
+    "issue-next-week-offering-c11"
+  ]
+}

--- a/docs/ai/decisions.md
+++ b/docs/ai/decisions.md
@@ -4,6 +4,24 @@ Append-only log of architecture / workflow decisions worth preserving across ses
 
 ---
 
+## 2026-06-08 — next-week-offering: per-project opt-* gate, first-line cause rule, offering decoupled from volunteer checkbox
+
+**Context.** Visalia CRC's bulletin OFFERING text comes from the selected week's PCO note; the "next week's offering is for X" line was typed by hand. Automate it: on import + re-sync, pull the next plan's OFFERING note and append the line to this week's OFFERING item.
+
+**Decision — gate is a per-project `opt-next-week-offering` checkbox, not a global `settings.autoNextWeekOffering`.** The task floated a global setting, but there is no exported frontend settings getter (`_serverSettings` is module-private in `api.js`), and the user asked for the toggle to live in the Document Options dropdown alongside the existing `opt-*` page-inclusion checkboxes. Implemented exactly like the siblings: `state.js` DOM ref, `projects.js` collect (`!!checked`) + restore in both `applyProjectState` blocks (`!== false`, default ON) + reset-to-true in `clearEditorForNewProject`, `formatting.js` change listener (renderPreview + persist). Read at import time via the DOM ref. **Consequence:** the toggle is per-project (saved in project state), not a workspace/global default — matches the other Document Options toggles. Server mode unchanged.
+
+**Decision — cause = first non-empty line of the next OFFERING note** (strip surrounding `*`/`**`/`***`), per the user. Not "first bolded token." `deriveNextWeekOfferingCause` returns '' for blank/non-string so callers skip cleanly.
+
+**Decision — pure logic in `pco-core.js`, exposed via the `main.js` globalThis bridge.** `deriveNextWeekOfferingCause` + `applyNextWeekOfferingLine` are pure and vitest-tested (7 contract tests c1–c7). `applyNextWeekOfferingLine` always strips any existing managed line (matched by the `NEXT_WEEK_OFFERING_PREFIX` constant) before appending, so re-running is idempotent and a new cause replaces the old in place; an empty cause removes-only. This is what makes re-sync non-duplicating even though the re-sync merge restores the user's prior detail (which already contains the previous line).
+
+**Decision — offering refresh is decoupled from the volunteer checkbox.** `pcoFetchAndApplyServing` is invoked from the resync diff dialog's Apply handler **only when the volunteer checkbox is checked** (`serveCallback`). The offering line must refresh on every applied re-sync regardless, so a separate `offeringCallback` param was added to `showResyncDiffDialog` and is invoked unconditionally (after conflict resolution, so it sees the OFFERING item's final detail). On the import path and the no-changes resync path it is called directly next to `pcoFetchAndApplyServing`.
+
+**Decision — underivable/missing cases silently skip** (no next plan, no next OFFERING note, no OFFERING item, empty cause, feature toggled off): the wiring early-returns and leaves detail untouched, per the "silently skip" requirement, rather than stripping a stale line. The whole next-plan fetch is wrapped in try/catch (best-effort) mirroring `pcoFetchAndApplyServing`, so a failure never breaks the import.
+
+**Consequences.** New `pcoFetchAndApplyNextWeekOffering` in `pco.js`; one extra param on `showResyncDiffDialog`; additive `opt-*` checkbox. c8–c11 (live import/re-sync behavior, gate suppression, best-effort failure) are manual-smoke only — no module seam around `pcoGet`/DOM.
+
+---
+
 ## 2026-06-06 — Issues #279 + #280: PID lock file for stale-sidecar detection; onedir for cold-start
 
 **Context.** Issue #279: if the Electron app crashes (bypassing `before-quit`), the Python sidecar stays alive holding port 8765. On next launch, the new sidecar bind fails with a raw OSError traceback → Electron shows "Exit code 1". Issue #280: PyInstaller `--onefile` unpacks the whole runtime to a temp dir on every launch; `--onedir` copies once and stays.

--- a/docs/ai/project-state.md
+++ b/docs/ai/project-state.md
@@ -116,6 +116,11 @@ The Playwright E2E suite (core lane) now runs as a PR gate on every PR (`e2e-cor
 
 ## Recent coding-agent runs
 
+### 2026-06-08 — next-week-offering follow-ups (branch `fix/next-week-offering`)
+- **Import-path stale-ref fix (commit `1643bcd`):** `pcoFetchAndApplyNextWeekOffering` captured the OFFERING item ref before its `await pcoGet` calls; the import flow replaces `items[]` during the awaits → orphaned ref → line dropped on fresh import (only appeared after a re-sync). Fixed: cheap `items.some()` presence check up front, then re-find the live OFFERING item after the awaits before mutating. **User-confirmed PASS on live import.**
+- **Bold this-week's offering cause (this commit):** new pure `boldFirstLine(text)` in `pco-core.js` (wrap first non-empty line in `**…**`, idempotent, no-op for blank) + exposed via `main.js` bridge. Wired in `applyPcoData` after `mapPlanNotesToItems`: bolds the OFFERING item's first line (the charity/cause) so it renders bold like the next-week line. Gated by the same toggle, now relabeled **"Auto-format offering (bold cause + next week's line)"** in `index.html`. 3 vitest tests (c12). On re-sync the merge restores the user's saved detail, so manual un-bolding is preserved.
+- Verification: `npm test` → 133 passed/1 skipped; `npm run build` green; served-bundle smoke (boldFirstLineCore wired + idempotent, checkbox relabeled/default-on).
+
 ### 2026-06-08 — next-week-offering (branch `fix/next-week-offering`)
 - Feature: on PCO import + re-sync, auto-append `Next week's offering is for **<cause>**` to this week's OFFERING section item.detail, where `<cause>` = first non-empty line of the NEXT upcoming plan's OFFERING note (bold markers stripped). Idempotent, best-effort, preserves manual edits, gated per-project by an `opt-next-week-offering` checkbox (default ON) in Document Options.
 - Files modified:

--- a/docs/ai/project-state.md
+++ b/docs/ai/project-state.md
@@ -79,6 +79,7 @@ The Playwright E2E suite (core lane) now runs as a PR gate on every PR (`e2e-cor
 
 ## In progress
 
+- **next-week-offering manual smoke pending** (branch `fix/next-week-offering`, draft PR to open). Verified PASS automated (130 vitest incl. 7 new contract tests c1–c7, vite build, served-bundle checkbox/wiring smoke). Manual criteria c8–c11 (contract `not_tested`) need live PCO: (1) import a plan whose next week has an OFFERING note → "Next week's offering is for **<cause>**" appears once on this week's OFFERING item; (2) re-sync → no duplicate; (3) uncheck the Document Options "Auto-add next week's offering line" box → suppressed on next import/re-sync, persists across reload; (4) force a next-plan fetch failure → import still completes.
 - Manual smoke for issue 023 pending — requires live Supabase session + two users:
   1. Owner opens workspace project → no readonly-banner, autosave fires.
   2. Non-owner opens same project → readonly-banner appears, edits suppressed, Duplicate creates private copy.
@@ -104,6 +105,7 @@ The Playwright E2E suite (core lane) now runs as a PR gate on every PR (`e2e-cor
 
 ## Next step
 
+0. **Open draft PR for `fix/next-week-offering`** (next-week-offering feature) and hand off for manual PCO smoke (c8–c11 above). Do not merge.
 1. **Open draft PR** for `feat/desktop-anon-key-rls` (covers #224, #225, #279, #280, #294 and all prior work on this branch). Update PR #293 description to include #294.
 2. **Manual smoke handoff for #279/#280/#294** — trigger a build, crash the app, relaunch; confirm (a) stale-sidecar reap clears port without "Exit code 1" dialog, (b) cold-start is noticeably faster with onedir, (c) PCO import and Google Calendar work in the packaged Electron build (requires `SUPABASE_URL` + `SUPABASE_ANON_KEY` bundled and a Supabase JWT forwarded from renderer).
 3. **277-F** — after PR #293 merged + Electron smoke passes: remove `DATABASE_URL` from `release-electron.yml`, flip `APP_MODE=electron` in the Electron sidecar spawn, verify sidecar boots cleanly without DATABASE_URL. This closes the 🔴 extractable-creds risk.
@@ -113,6 +115,32 @@ The Playwright E2E suite (core lane) now runs as a PR gate on every PR (`e2e-cor
    - Data migration dry-run: `python scripts/migrate_to_supabase.py --source /Volumes/docker/bulletingenerator/app/data`
 
 ## Recent coding-agent runs
+
+### 2026-06-08 — next-week-offering (branch `fix/next-week-offering`)
+- Feature: on PCO import + re-sync, auto-append `Next week's offering is for **<cause>**` to this week's OFFERING section item.detail, where `<cause>` = first non-empty line of the NEXT upcoming plan's OFFERING note (bold markers stripped). Idempotent, best-effort, preserves manual edits, gated per-project by an `opt-next-week-offering` checkbox (default ON) in Document Options.
+- Files modified:
+  - `src/js/modules/pco-core.js` — new pure exports `NEXT_WEEK_OFFERING_PREFIX`, `deriveNextWeekOfferingCause(noteBody)` (first non-empty line, strip `*`/`**`/`***`, '' for blank/non-string), `applyNextWeekOfferingLine(detail, cause)` (strip any existing managed line, then append; empty cause = remove-only/no-op; preserves body above).
+  - `src/js/main.js` — import both new core fns and expose on `globalThis` as `deriveNextWeekOfferingCauseCore` / `applyNextWeekOfferingLineCore` (legacy-script bridge pattern).
+  - `src/js/pco.js` — new best-effort async `pcoFetchAndApplyNextWeekOffering(stId, planId, planSortDate)`: gate on `optNextWeekOffering`, find OFFERING section item, fetch first future plan with `sort_date > current` (reuses the serving query), read its OFFERING note via `normalizePlanNotes`, derive cause, apply line, re-render. Wired at 3 sites: import (after `pcoFetchAndApplyServing`), no-changes resync path, and resync diff dialog via a new unconditional `offeringCallback` param to `showResyncDiffDialog` (independent of the volunteer checkbox).
+  - `src/js/state.js` — `optNextWeekOffering` DOM ref.
+  - `index.html` — `opt-next-week-offering` checkbox (checked) in the Options dropdown.
+  - `src/js/projects.js` — collect (`!!optNextWeekOffering.checked`), restore in both `applyProjectState` blocks (`!== false`, default ON), reset to true in `clearEditorForNewProject`.
+  - `src/js/formatting.js` — change listener (renderPreview + persist), matching the other `opt-*` toggles.
+  - `tests/pco-core.spec.js` — 7 contract tests (c1–c7).
+  - `docs/ai/contracts/issue-next-week-offering.json` — acceptance contract (11 criteria; 7 unit, 4 manual c8–c11).
+- Checks run (coding-agent stage):
+  - `node --check` on all 6 changed JS files → PASS.
+  - `npx vitest run tests/pco-core.spec.js` → 9 passed (2 pre-existing + 7 new). Red-before-green confirmed (7 failed pre-implementation).
+  - Full `npm test` + `npm run build` → pending verification-gate.
+- Decisions made:
+  - Per-project `opt-*` checkbox (not a global `settings.autoNextWeekOffering` getter) — matches existing Document Options pattern, no exported settings accessor exists, reads cleanly at import time. User-approved (default ON, toggle in Document Options).
+  - Cause rule = first non-empty line (user decision), not first-bolded-token.
+  - Offering refresh decoupled from the volunteer checkbox via a dedicated `offeringCallback`, since `serveCallback` only fires when the volunteer box is checked.
+  - On empty/underivable cause the function silently skips (leaves detail untouched) per "silently skip" requirement, rather than stripping a stale line.
+- Deviations from spec: contract tests live in `tests/pco-core.spec.js` (repo vitest convention), not `tests/contract/` (acceptance-contract default) — AGENTS.md convention takes precedence.
+- Concerns:
+  - c8–c11 are manual-smoke only (live PCO OAuth + a plan whose next week has an OFFERING note): confirm line appears once on import, no duplicate on re-sync, gate suppresses when unchecked, best-effort survives a forced next-plan fetch failure.
+  - `worship-booklet.html` legacy standalone file not updated (not part of the modular build; pre-existing known gap).
 
 ### 2026-06-08 — issue-294-electron-supabase-rest-settings
 - Files modified:

--- a/index.html
+++ b/index.html
@@ -202,7 +202,7 @@
         <label class="opt-row flex items-center gap-1.5 text-sm mb-1 cursor-pointer"><input type="checkbox" class="checkbox checkbox-xs checkbox-primary" id="opt-volunteers" checked /> Include volunteers / serving schedule</label>
         <label class="opt-row flex items-center gap-1.5 text-sm mb-1 cursor-pointer"><input type="checkbox" class="checkbox checkbox-xs checkbox-primary" id="opt-volunteer-roles" checked /> Include volunteer roles page</label>
         <label class="opt-row flex items-center gap-1.5 text-sm mb-1 cursor-pointer"><input type="checkbox" class="checkbox checkbox-xs checkbox-primary" id="opt-staff" checked /> Include staff &amp; contact page</label>
-        <label class="opt-row flex items-center gap-1.5 text-sm mb-1 cursor-pointer"><input type="checkbox" class="checkbox checkbox-xs checkbox-primary" id="opt-next-week-offering" checked /> Auto-add next week&apos;s offering line</label>
+        <label class="opt-row flex items-center gap-1.5 text-sm mb-1 cursor-pointer"><input type="checkbox" class="checkbox checkbox-xs checkbox-primary" id="opt-next-week-offering" checked /> Auto-format offering (bold cause + next week&apos;s line)</label>
         <div class="form-control mt-2">
           <label class="label py-0.5"><span class="label-text text-xs">Booklet size target</span></label>
           <select class="select select-bordered select-sm w-full" id="opt-booklet-size">

--- a/index.html
+++ b/index.html
@@ -202,6 +202,7 @@
         <label class="opt-row flex items-center gap-1.5 text-sm mb-1 cursor-pointer"><input type="checkbox" class="checkbox checkbox-xs checkbox-primary" id="opt-volunteers" checked /> Include volunteers / serving schedule</label>
         <label class="opt-row flex items-center gap-1.5 text-sm mb-1 cursor-pointer"><input type="checkbox" class="checkbox checkbox-xs checkbox-primary" id="opt-volunteer-roles" checked /> Include volunteer roles page</label>
         <label class="opt-row flex items-center gap-1.5 text-sm mb-1 cursor-pointer"><input type="checkbox" class="checkbox checkbox-xs checkbox-primary" id="opt-staff" checked /> Include staff &amp; contact page</label>
+        <label class="opt-row flex items-center gap-1.5 text-sm mb-1 cursor-pointer"><input type="checkbox" class="checkbox checkbox-xs checkbox-primary" id="opt-next-week-offering" checked /> Auto-add next week&apos;s offering line</label>
         <div class="form-control mt-2">
           <label class="label py-0.5"><span class="label-text text-xs">Booklet size target</span></label>
           <select class="select select-bordered select-sm w-full" id="opt-booklet-size">

--- a/src/js/formatting.js
+++ b/src/js/formatting.js
@@ -266,6 +266,7 @@ function initFormattingControls() {
   optVolunteers.addEventListener('change',    () => { renderPreview(); scheduleProjectPersist(); });
   optVolunteerRoles.addEventListener('change',() => { renderPreview(); scheduleProjectPersist(); });
   optStaff.addEventListener('change',         () => { renderPreview(); scheduleProjectPersist(); });
+  optNextWeekOffering.addEventListener('change', () => { renderPreview(); scheduleProjectPersist(); });
 
   document.getElementById('fmt-save-btn').addEventListener('click', () => {
     saveTypeFormats();

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -50,6 +50,8 @@ import {
 } from './modules/projects-core.js';
 import {
   mapPcoItemType as mapPcoItemTypeCore,
+  deriveNextWeekOfferingCause as deriveNextWeekOfferingCauseCore,
+  applyNextWeekOfferingLine as applyNextWeekOfferingLineCore,
 } from './modules/pco-core.js';
 
 // Expose supabase-data.js functions on globalThis so the legacy renderer
@@ -102,6 +104,8 @@ Object.assign(globalThis, {
   deriveProjectSaveFailureCore,
   deriveStartupRestoreCore,
   mapPcoItemTypeCore,
+  deriveNextWeekOfferingCauseCore,
+  applyNextWeekOfferingLineCore,
 });
 
 export const LEGACY_SCRIPT_PATHS = [

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -52,6 +52,7 @@ import {
   mapPcoItemType as mapPcoItemTypeCore,
   deriveNextWeekOfferingCause as deriveNextWeekOfferingCauseCore,
   applyNextWeekOfferingLine as applyNextWeekOfferingLineCore,
+  boldFirstLine as boldFirstLineCore,
 } from './modules/pco-core.js';
 
 // Expose supabase-data.js functions on globalThis so the legacy renderer
@@ -106,6 +107,7 @@ Object.assign(globalThis, {
   mapPcoItemTypeCore,
   deriveNextWeekOfferingCauseCore,
   applyNextWeekOfferingLineCore,
+  boldFirstLineCore,
 });
 
 export const LEGACY_SCRIPT_PATHS = [

--- a/src/js/modules/pco-core.js
+++ b/src/js/modules/pco-core.js
@@ -53,3 +53,23 @@ export function applyNextWeekOfferingLine(detail, cause) {
   const line = `${NEXT_WEEK_OFFERING_PREFIX} **${c}**`;
   return cleaned ? `${cleaned}\n${line}` : line;
 }
+
+// Wrap the first non-empty line of a detail block in markdown bold (`**…**`),
+// so this week's offering charity/cause renders bold like the next-week line.
+// Idempotent (a line already wrapped in `**…**` is left untouched) and a no-op
+// for blank / non-string input. The rest of the body is preserved verbatim.
+export function boldFirstLine(text) {
+  const base = String(text == null ? '' : text);
+  const lines = base.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+    if (!trimmed) continue;
+    if (/^\*\*[\s\S]*\*\*$/.test(trimmed)) return base; // already bold — idempotent
+    const inner = trimmed.replace(/^\*{1,3}/, '').replace(/\*{1,3}$/, '').trim();
+    if (!inner) return base;
+    const leading = lines[i].match(/^\s*/)[0];
+    lines[i] = `${leading}**${inner}**`;
+    return lines.join('\n');
+  }
+  return base;
+}

--- a/src/js/modules/pco-core.js
+++ b/src/js/modules/pco-core.js
@@ -13,3 +13,43 @@ export function mapPcoItemType(attrs = {}) {
   if (attrs.item_type === 'media') return 'media';
   return 'label';
 }
+
+// ─── Next week's offering addendum ──────────────────────────────────────────
+// Prefix used for the auto-managed trailing line on the OFFERING item.detail.
+// Kept as a constant so derivation, append, and idempotent-replace all agree.
+export const NEXT_WEEK_OFFERING_PREFIX = "Next week's offering is for";
+
+// Derive the offering <cause> from the NEXT week's OFFERING note body.
+// Rule (per church convention): the first non-empty line of the note, trimmed,
+// with any surrounding markdown emphasis markers (* / ** / ***) stripped.
+// Returns '' for blank / non-string input so callers can skip cleanly.
+export function deriveNextWeekOfferingCause(noteBody) {
+  if (typeof noteBody !== 'string') return '';
+  for (const raw of noteBody.split('\n')) {
+    const line = raw.trim();
+    if (!line) continue;
+    return line.replace(/^\*{1,3}/, '').replace(/\*{1,3}$/, '').trim();
+  }
+  return '';
+}
+
+// Append (or idempotently replace) the managed "Next week's offering is for
+// **<cause>**" line at the end of an OFFERING item's detail.
+// - Existing managed lines (matched by NEXT_WEEK_OFFERING_PREFIX) are always
+//   stripped first, so re-running never duplicates and a new cause replaces the
+//   old one in place.
+// - The body above the managed line is preserved verbatim (manual edits safe).
+// - An empty / falsy cause removes any managed line and adds nothing (no-op for
+//   plain detail), so disabling the feature or a missing next-note self-heals.
+export function applyNextWeekOfferingLine(detail, cause) {
+  const base = String(detail == null ? '' : detail);
+  const cleaned = base
+    .split('\n')
+    .filter(line => !line.trimStart().startsWith(NEXT_WEEK_OFFERING_PREFIX))
+    .join('\n')
+    .replace(/\s+$/, '');
+  const c = String(cause == null ? '' : cause).trim();
+  if (!c) return cleaned;
+  const line = `${NEXT_WEEK_OFFERING_PREFIX} **${c}**`;
+  return cleaned ? `${cleaned}\n${line}` : line;
+}

--- a/src/js/pco.js
+++ b/src/js/pco.js
@@ -130,6 +130,8 @@ document.getElementById('pco-import-btn').addEventListener('click', async () => 
     // Fetch serving schedule in background (non-blocking)
     pcoFetchAndApplyServing(stId, planId,
       planResp.data.attributes.sort_date, planResp.data.attributes.dates);
+    // Append next week's offering cause (best-effort, non-blocking)
+    pcoFetchAndApplyNextWeekOffering(stId, planId, planResp.data.attributes.sort_date);
   } catch (err) {
     pcoSetMsg('pco-import-msg', err.message, 'error');
   } finally {
@@ -293,6 +295,9 @@ function applyPcoData(planResp, itemsResp, notesResp, isResync = false, servingP
           servingParams.stId, servingParams.planId,
           servingParams.sortDate, servingParams.date
         );
+        pcoFetchAndApplyNextWeekOffering(
+          servingParams.stId, servingParams.planId, servingParams.sortDate
+        );
       }
       return;
     }
@@ -303,8 +308,15 @@ function applyPcoData(planResp, itemsResp, notesResp, isResync = false, servingP
           servingParams.sortDate, servingParams.date
         )
       : null;
+    // Independent of the volunteer checkbox — the offering line should refresh on
+    // every applied re-sync, so it is invoked unconditionally from the dialog.
+    const offeringCallback = servingParams
+      ? () => pcoFetchAndApplyNextWeekOffering(
+          servingParams.stId, servingParams.planId, servingParams.sortDate
+        )
+      : null;
 
-    showResyncDiffDialog(diff, refreshConflicts, pendingWithNotes, pendingUnmatched, serveCallback);
+    showResyncDiffDialog(diff, refreshConflicts, pendingWithNotes, pendingUnmatched, serveCallback, offeringCallback);
     return;
   }
 
@@ -948,6 +960,48 @@ async function pcoFetchAndApplyServing(stId, planId, planSortDate, planDate) {
   }
 }
 
+// Best-effort: append/replace "Next week's offering is for **<cause>**" on this
+// week's OFFERING section item, deriving <cause> from the first non-empty line of
+// the NEXT upcoming plan's OFFERING note. Gated by the per-project
+// opt-next-week-offering toggle (default on). Idempotent (replaces any existing
+// managed line) and fully swallowed on error so it never breaks the import.
+async function pcoFetchAndApplyNextWeekOffering(stId, planId, planSortDate) {
+  try {
+    if (optNextWeekOffering && !optNextWeekOffering.checked) return; // feature toggled off
+    const offeringNorm = normTitle('OFFERING');
+    const offeringItem = items.find(it =>
+      it.type === 'section' && normTitle(it.title) === offeringNorm
+    );
+    if (!offeringItem) return; // no OFFERING item this week — skip silently
+
+    // Next upcoming plan = first plan with sort_date strictly after this one.
+    const futurePlans = await pcoGet(
+      `/service_types/${stId}/plans?filter=future&order=sort_date&per_page=25`
+    );
+    const nextPlan = (futurePlans.data || []).find(p =>
+      p.id !== planId && (p.attributes.sort_date || '') > (planSortDate || '')
+    );
+    if (!nextPlan) return; // no next plan — skip
+
+    const notesResp = await pcoGet(
+      `/service_types/${stId}/plans/${nextPlan.id}/notes`
+    );
+    const offeringNote = normalizePlanNotes(notesResp).find(n =>
+      n.normalizedTitle === offeringNorm
+    );
+    const cause = deriveNextWeekOfferingCauseCore(offeringNote ? offeringNote.body : '');
+    if (!cause) return; // no derivable cause — leave detail untouched (silent skip)
+
+    offeringItem.detail = applyNextWeekOfferingLineCore(offeringItem.detail, cause);
+    renderItemList();
+    renderPreview();
+    scheduleProjectPersist();
+  } catch (e) {
+    // best-effort — must never break the import/resync flow
+    console.warn("Could not apply next week's offering:", e);
+  }
+}
+
 function pcoSaveLastImport(serviceTypeId, planId, planLabel) {
   localStorage.setItem(PCO_LAST_IMPORT_KEY, JSON.stringify({ serviceTypeId, planId, planLabel }));
 }
@@ -1238,7 +1292,9 @@ function showRefreshConflictsDialog(conflicts, pendingWithNotes = [], pendingUnm
 // Shows all inconsistencies between the current project and the live PCO plan.
 // Called only on resync (isResync=true in applyPcoData), not on initial import.
 // serveCallback: () => void called from Apply if the volunteer checkbox is checked.
-function showResyncDiffDialog(diff, refreshConflicts, pendingWithNotes, pendingUnmatched, serveCallback) {
+// offeringCallback: () => void called from Apply unconditionally (next week's
+// offering line refreshes on every applied re-sync, independent of volunteers).
+function showResyncDiffDialog(diff, refreshConflicts, pendingWithNotes, pendingUnmatched, serveCallback, offeringCallback) {
   const body = document.getElementById('irm-body');
   body.innerHTML = '';
 
@@ -1482,6 +1538,11 @@ function showResyncDiffDialog(diff, refreshConflicts, pendingWithNotes, pendingU
 
     // Volunteer schedule (call async serving fetch if checkbox checked)
     if (applyServing && serveCallback) serveCallback();
+
+    // Next week's offering — refresh unconditionally (best-effort, independent
+    // of the volunteer checkbox). Runs after conflict resolution so it operates
+    // on the OFFERING item's final detail.
+    if (offeringCallback) offeringCallback();
 
     // Song review (existing)
     irmApplyWithNotes(pendingWithNotes, withNotesSels);

--- a/src/js/pco.js
+++ b/src/js/pco.js
@@ -212,6 +212,18 @@ function applyPcoData(planResp, itemsResp, notesResp, isResync = false, servingP
   if (notesResp) {
     const normalizedNotes = normalizePlanNotes(notesResp);
     mapPlanNotesToItems(items, normalizedNotes);
+    // Bold the first line (the charity/cause) of THIS week's OFFERING item,
+    // mirroring how the next-week cause renders bold. Gated by the same
+    // Document Options toggle. Applied to the freshly-filled detail; on re-sync
+    // the merge below restores the user's saved detail, so manual un-bolding is
+    // preserved. Idempotent via boldFirstLine.
+    if (!optNextWeekOffering || optNextWeekOffering.checked) {
+      const offNorm = normTitle('OFFERING');
+      const offItem = items.find(it =>
+        it.type === 'section' && normTitle(it.title) === offNorm
+      );
+      if (offItem && offItem.detail) offItem.detail = boldFirstLineCore(offItem.detail);
+    }
   }
 
   // Re-sync merge: for items that existed before, restore all user edits.

--- a/src/js/pco.js
+++ b/src/js/pco.js
@@ -969,10 +969,10 @@ async function pcoFetchAndApplyNextWeekOffering(stId, planId, planSortDate) {
   try {
     if (optNextWeekOffering && !optNextWeekOffering.checked) return; // feature toggled off
     const offeringNorm = normTitle('OFFERING');
-    const offeringItem = items.find(it =>
+    const hasOffering = items.some(it =>
       it.type === 'section' && normTitle(it.title) === offeringNorm
     );
-    if (!offeringItem) return; // no OFFERING item this week — skip silently
+    if (!hasOffering) return; // no OFFERING item this week — skip the network call
 
     // Next upcoming plan = first plan with sort_date strictly after this one.
     const futurePlans = await pcoGet(
@@ -992,6 +992,15 @@ async function pcoFetchAndApplyNextWeekOffering(stId, planId, planSortDate) {
     const cause = deriveNextWeekOfferingCauseCore(offeringNote ? offeringNote.body : '');
     if (!cause) return; // no derivable cause — leave detail untouched (silent skip)
 
+    // Re-resolve the OFFERING item against the LIVE items[] array — during the
+    // awaits above the import flow can replace items[] (enrich + song-review
+    // apply, or the re-sync merge), which would orphan a reference captured
+    // earlier and silently drop the line. This is why a fresh import showed
+    // nothing while a re-sync (which runs after items are finalized) worked.
+    const offeringItem = items.find(it =>
+      it.type === 'section' && normTitle(it.title) === offeringNorm
+    );
+    if (!offeringItem) return;
     offeringItem.detail = applyNextWeekOfferingLineCore(offeringItem.detail, cause);
     renderItemList();
     renderPreview();

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -185,6 +185,7 @@ function collectCurrentProjectState() {
     optVolunteers:    !!optVolunteers.checked,
     optVolunteerRoles:!!optVolunteerRoles.checked,
     optStaff:         !!optStaff.checked,
+    optNextWeekOffering: !!optNextWeekOffering.checked,
     welcomeHeading: welcomeHeading || '',
     welcomeItems: welcomeItems.slice(),
     announcements: annData.map(a => ({ title: a.title || '', body: a.body || '', url: a.url || '', _breakBefore: !!a._breakBefore, _noBreakBefore: !!a._noBreakBefore })),
@@ -229,6 +230,7 @@ function applyProjectState(state) {
   optVolunteers.checked    = safe.optVolunteers !== false;
   optVolunteerRoles.checked= safe.optVolunteerRoles !== false;
   optStaff.checked         = safe.optStaff !== false;
+  optNextWeekOffering.checked = safe.optNextWeekOffering !== false;
   setItems(Array.isArray(safe.items) ? cloneItems(safe.items) : []);
   renderItemList();
   applyCoverImage(safe.coverImageUrl || null, '(saved image)');
@@ -622,6 +624,7 @@ function clearEditorForNewProject() {
   optVolunteers.checked    = true;
   optVolunteerRoles.checked= true;
   optStaff.checked         = true;
+  optNextWeekOffering.checked = true;
   // Seed announcements and welcome items from the most recently dated saved project
   const datedProjects = projects
     .filter(p => p.state?.announcements && p.state?.svcDate)
@@ -949,6 +952,7 @@ function applyProjectStateForExport(state) {
   optVolunteers.checked = safe.optVolunteers !== false;
   optVolunteerRoles.checked = safe.optVolunteerRoles !== false;
   optStaff.checked = safe.optStaff !== false;
+  optNextWeekOffering.checked = safe.optNextWeekOffering !== false;
   setItems(Array.isArray(safe.items) ? cloneItems(safe.items) : []);
   setAnnData(Array.isArray(safe.announcements)
     ? safe.announcements.map(a => ({ title: a.title || '', body: a.body || '', url: a.url || '', _breakBefore: !!a._breakBefore, _noBreakBefore: !!a._noBreakBefore }))

--- a/src/js/state.js
+++ b/src/js/state.js
@@ -290,6 +290,7 @@ const optAnnouncements     = document.getElementById('opt-announcements');
 const optVolunteers        = document.getElementById('opt-volunteers');
 const optVolunteerRoles    = document.getElementById('opt-volunteer-roles');
 const optStaff             = document.getElementById('opt-staff');
+const optNextWeekOffering  = document.getElementById('opt-next-week-offering');
 const pageCountDisplay     = document.getElementById('page-count-display');
 const itemList             = document.getElementById('item-list');
 const addItemBtn           = document.getElementById('add-item-btn');

--- a/tests/pco-core.spec.js
+++ b/tests/pco-core.spec.js
@@ -3,6 +3,7 @@ import {
   mapPcoItemType,
   deriveNextWeekOfferingCause,
   applyNextWeekOfferingLine,
+  boldFirstLine,
 } from '../src/js/modules/pco-core.js';
 
 describe('PCO item mapping', () => {
@@ -87,5 +88,28 @@ describe('applyNextWeekOfferingLine', () => {
     const withLine = applyNextWeekOfferingLine('Body.', 'Faith Promise');
     expect(applyNextWeekOfferingLine(withLine, '')).toBe('Body.');
     expect(applyNextWeekOfferingLine(withLine, '')).not.toContain('Next week');
+  });
+});
+
+describe('boldFirstLine', () => {
+  it('issue-next-week-offering-c12: bolds the first non-empty line', () => {
+    expect(boldFirstLine('GEMS International\n"Girls Everywhere…" equips women.'))
+      .toBe('**GEMS International**\n"Girls Everywhere…" equips women.');
+    // leading blank lines are skipped; the rest of the body is preserved verbatim
+    expect(boldFirstLine('\n\nFaith Promise\nmore detail'))
+      .toBe('\n\n**Faith Promise**\nmore detail');
+  });
+
+  it('issue-next-week-offering-c12: idempotent — does not double-bold', () => {
+    expect(boldFirstLine('**GEMS International**\ndesc')).toBe('**GEMS International**\ndesc');
+    expect(boldFirstLine(boldFirstLine('GEMS International\ndesc')))
+      .toBe('**GEMS International**\ndesc');
+  });
+
+  it('issue-next-week-offering-c12: blank / non-string returns unchanged', () => {
+    expect(boldFirstLine('')).toBe('');
+    expect(boldFirstLine('   \n  ')).toBe('   \n  ');
+    expect(boldFirstLine(null)).toBe('');
+    expect(boldFirstLine(undefined)).toBe('');
   });
 });

--- a/tests/pco-core.spec.js
+++ b/tests/pco-core.spec.js
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { mapPcoItemType } from '../src/js/modules/pco-core.js';
+import {
+  mapPcoItemType,
+  deriveNextWeekOfferingCause,
+  applyNextWeekOfferingLine,
+} from '../src/js/modules/pco-core.js';
 
 describe('PCO item mapping', () => {
   it('maps the children dismissed header to a label', () => {
@@ -14,5 +18,74 @@ describe('PCO item mapping', () => {
       item_type: 'header',
       title: 'WORD',
     })).toBe('section');
+  });
+});
+
+// ─── Next week's offering addendum (issue next-week-offering) ────────────────
+
+describe('deriveNextWeekOfferingCause', () => {
+  it('issue-next-week-offering-c1: derives first non-empty line', () => {
+    // leading blank lines are skipped; the first content line is the cause
+    expect(deriveNextWeekOfferingCause('\n\n  Faith Promise  \nSome details below'))
+      .toBe('Faith Promise');
+    expect(deriveNextWeekOfferingCause('Benevolence Fund'))
+      .toBe('Benevolence Fund');
+  });
+
+  it('issue-next-week-offering-c2: strips bold markers', () => {
+    expect(deriveNextWeekOfferingCause('**Faith Promise**')).toBe('Faith Promise');
+    expect(deriveNextWeekOfferingCause('  **World Renew**  \nextra')).toBe('World Renew');
+    // a single trailing/leading asterisk pair should also be cleaned
+    expect(deriveNextWeekOfferingCause('*Deacon Fund*')).toBe('Deacon Fund');
+  });
+
+  it('issue-next-week-offering-c3: blank note yields empty cause', () => {
+    expect(deriveNextWeekOfferingCause('')).toBe('');
+    expect(deriveNextWeekOfferingCause('   \n  \n ')).toBe('');
+    expect(deriveNextWeekOfferingCause(null)).toBe('');
+    expect(deriveNextWeekOfferingCause(undefined)).toBe('');
+  });
+});
+
+describe('applyNextWeekOfferingLine', () => {
+  const LINE = (cause) => `Next week's offering is for **${cause}**`;
+
+  it('issue-next-week-offering-c4: appends line when absent', () => {
+    const result = applyNextWeekOfferingLine('This week we collect for the General Fund.', 'Faith Promise');
+    expect(result).toBe(`This week we collect for the General Fund.\n${LINE('Faith Promise')}`);
+    // appending to empty detail yields just the line (no leading newline)
+    expect(applyNextWeekOfferingLine('', 'Faith Promise')).toBe(LINE('Faith Promise'));
+  });
+
+  it('issue-next-week-offering-c5: idempotent replace, never duplicates', () => {
+    const once = applyNextWeekOfferingLine('Body text.', 'Faith Promise');
+    // re-running with the same cause is a no-op
+    expect(applyNextWeekOfferingLine(once, 'Faith Promise')).toBe(once);
+    // re-running with a new cause replaces in place — exactly one managed line
+    const replaced = applyNextWeekOfferingLine(once, 'World Renew');
+    expect(replaced).toBe(`Body text.\n${LINE('World Renew')}`);
+    const occurrences = (replaced.match(/Next week's offering is for/g) || []).length;
+    expect(occurrences).toBe(1);
+  });
+
+  it('issue-next-week-offering-c6: preserves existing body', () => {
+    const body = 'Line one of offering text.\nLine two with details.';
+    const result = applyNextWeekOfferingLine(body, 'Benevolence');
+    expect(result.startsWith(body)).toBe(true);
+    expect(result).toContain(LINE('Benevolence'));
+    // replacing the managed line keeps the full original body intact
+    const replaced = applyNextWeekOfferingLine(result, 'Deacon Fund');
+    expect(replaced.startsWith(body)).toBe(true);
+    expect(replaced).not.toContain('Benevolence');
+  });
+
+  it("issue-next-week-offering-c7: empty cause is a no-op / clears stale line", () => {
+    // empty cause against plain detail: unchanged, no dangling line
+    expect(applyNextWeekOfferingLine('Just the body.', '')).toBe('Just the body.');
+    expect(applyNextWeekOfferingLine('Just the body.', null)).toBe('Just the body.');
+    // empty cause against detail that already has a managed line: line removed
+    const withLine = applyNextWeekOfferingLine('Body.', 'Faith Promise');
+    expect(applyNextWeekOfferingLine(withLine, '')).toBe('Body.');
+    expect(applyNextWeekOfferingLine(withLine, '')).not.toContain('Next week');
   });
 });


### PR DESCRIPTION
## Summary

Automates the "Next week's offering is for **<cause>**" line on the bulletin's OFFERING item. Previously typed by hand; now derived on PCO import and re-sync from the **next upcoming plan's** OFFERING note.

- On import + re-sync, fetch the next plan (first `sort_date >` current — reuses the serving-schedule query) and its OFFERING note.
- `<cause>` = **first non-empty line** of that note (surrounding `*`/`**`/`***` stripped).
- Append/replace `Next week's offering is for **<cause>**` on its own line at the end of **this week's** OFFERING section `item.detail`.
- **Idempotent** — re-running replaces the managed line in place, never duplicates.
- **Best-effort** — any next-plan fetch failure is swallowed and never breaks the import (mirrors `pcoFetchAndApplyServing`).
- **Preserves manual edits** — only the trailing managed line is touched.
- **Silently skips** when there is no next plan, no next OFFERING note, no OFFERING item, or no derivable cause.
- **Gated** per-project by a new **Auto-add next week's offering line** checkbox in Document Options (default ON).
- Works in both Electron and server mode (PCO proxy path is identical); server-mode `apiFetch` path for non-PCO flows is unchanged.

## Implementation

| File | Change |
|------|--------|
| `src/js/modules/pco-core.js` | Pure `deriveNextWeekOfferingCause` + `applyNextWeekOfferingLine` (+ `NEXT_WEEK_OFFERING_PREFIX`) |
| `src/js/main.js` | Expose both core fns on `globalThis` (legacy-script bridge) |
| `src/js/pco.js` | `pcoFetchAndApplyNextWeekOffering` (best-effort); wired on import, no-changes resync, and resync diff dialog via a new unconditional `offeringCallback` (decoupled from the volunteer checkbox) |
| `src/js/state.js` / `index.html` | `opt-next-week-offering` checkbox + DOM ref |
| `src/js/projects.js` | collect/restore (default ON via `!== false`) + reset |
| `src/js/formatting.js` | change listener (re-render + persist) |
| `tests/pco-core.spec.js` | 7 contract tests (c1–c7) |
| `docs/ai/contracts/issue-next-week-offering.json` | Acceptance contract (11 criteria) |

## Verification

- `npm test` → **130 passed | 1 skipped** (incl. 9 in `pco-core.spec.js`, 7 new). Red-before-green confirmed.
- `npm run build` (vite) → green.
- `node --check` on all 6 changed JS files → clean.
- Served-bundle smoke: checkbox present + default-checked + labeled; core fns wired and working end-to-end through the bundle; 0 console errors on boot.

## Manual smoke (pending — c8–c11, requires live PCO)

- [ ] Import a plan whose next week has an OFFERING note → line appears **once** on this week's OFFERING item.
- [ ] Re-sync → **no duplicate**.
- [ ] Uncheck "Auto-add next week's offering line" → suppressed on next import/re-sync; setting persists across reload.
- [ ] Force a next-plan fetch failure → import still completes.

**Do not merge** — manual smoke + human review required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)