### PR TITLE
fix(settings): strip reserved _-prefixed keys + e2e pollution sweep (#299)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           python-version: '3.11'
       - run: python -m pip install --upgrade pip pytest
-      - run: pytest tests/test_server_utils.py tests/test_update.py tests/test_drive.py tests/test_propresenter_export.py tests/test_issue_277_a_electron_db_mode.py tests/test_revision_snapshots.py tests/test_port_bind.py tests/test_supabase_rest_settings.py
+      - run: pytest tests/test_server_utils.py tests/test_update.py tests/test_drive.py tests/test_propresenter_export.py tests/test_issue_277_a_electron_db_mode.py tests/test_revision_snapshots.py tests/test_port_bind.py tests/test_supabase_rest_settings.py tests/contract/test_issue_299.py
 
   db-integration:
     # Only run on the canonical repo so forks without the required secrets

--- a/docs/ai/contracts/issue-299.json
+++ b/docs/ai/contracts/issue-299.json
@@ -1,0 +1,46 @@
+{
+  "issue": 299,
+  "generated": "2026-06-11",
+  "stack": "python",
+  "criteria": [
+    {
+      "criterion_id": "issue-299-c1",
+      "text": "Prevent recurrence: a settings write carrying a reserved (_-prefixed) test key must not land in production workspace_settings. The /api/settings POST handler strips/rejects _-prefixed keys.",
+      "mode": "unit",
+      "test_file": "tests/contract/test_issue_299.py",
+      "test_id": "TestPreventionGuard",
+      "status": "pending"
+    },
+    {
+      "criterion_id": "issue-299-c2",
+      "text": "Identify which keys are stray test keys: the sweep detects exactly the _-prefixed keys (e.g. _testKey, _screenshots) in a settings blob and leaves legitimate keys alone.",
+      "mode": "unit",
+      "test_file": "tests/contract/test_issue_299.py",
+      "test_id": "TestSweepDetection",
+      "status": "pending"
+    },
+    {
+      "criterion_id": "issue-299-c3",
+      "text": "Delete the stray keys from the production row: cleaning a settings blob removes every _-prefixed key while preserving all other keys; dry-run does not mutate.",
+      "mode": "unit",
+      "test_file": "tests/contract/test_issue_299.py",
+      "test_id": "TestSweepCleaning",
+      "status": "pending"
+    },
+    {
+      "criterion_id": "issue-299-c4",
+      "text": "SELECT jsonb_object_keys(settings) FROM workspace_settings shows no _-prefixed test keys (after the sweep executes against production).",
+      "mode": "manual",
+      "status": "UNVERIFIED",
+      "reason": "Requires executing the destructive sweep against the production Supabase workspace_settings row. Per task CAUTION, only the DRY-RUN is run in this PR; execution is a documented manual step. Verify after a human runs `python scripts/sweep_settings_test_keys.py --execute` against production."
+    },
+    {
+      "criterion_id": "issue-299-c5",
+      "text": "A full live-lane run leaves the production settings row byte-identical (excluding legitimately refreshed OAuth tokens).",
+      "mode": "manual",
+      "status": "UNVERIFIED",
+      "reason": "Requires running the @live Playwright lane against the production workspace and diffing the workspace_settings row before/after. Not automatable in this PR without writing to production. Verify via a workflow_dispatch of e2e-live.yml plus a before/after jsonb_object_keys diff."
+    }
+  ],
+  "not_tested": ["issue-299-c4", "issue-299-c5"]
+}

--- a/docs/ai/decisions.md
+++ b/docs/ai/decisions.md
@@ -4,6 +4,20 @@ Append-only log of architecture / workflow decisions worth preserving across ses
 
 ---
 
+## 2026-06-11 — Issue #299: `_`-prefix is a reserved test namespace in workspace_settings
+
+**Context.** The nightly E2E Live lane signs in as `e2e-live@e2e.bulletin.test`, a viewer in the **production** Visalia CRC workspace. `POST /api/settings` is merge-style, so any settings write a (now-removed) e2e spec performed merged into the production `workspace_settings` row, leaving `_testKey` and `_screenshots`. The dry-run sweep confirmed exactly those 2 keys in workspace `614505d2-…94fe` and no others.
+
+**Decision — define `_`-prefixed settings keys as a reserved test-only namespace.** The product uses no `_`-prefixed top-level settings key, so treating the `_` prefix as reserved gives a single, durable rule for both prevention and cleanup without enumerating individual test keys.
+
+**Decision — prevention is a server-side guard, not (only) a test convention.** `server.py` gains a pure `_strip_reserved_settings_keys(partial)` applied in `_handle_post_settings` before the merge, so a stray test write can never persist regardless of which client/spec sends it. The live-lane "read-only by convention" rule (documented in `tests/e2e/README.md` + a comment on the `live` project in `playwright.config.ts`) remains the primary rule; the server guard is defense-in-depth. Alternatives considered: rely on convention alone (rejected — already failed once); reject the whole POST with 4xx (rejected — would break a legit write that merely *includes* a stray key; silent strip is safer and matches the merge handler's forgiving style).
+
+**Decision — cleanup is a reviewable Python script, dry-run by default.** `scripts/sweep_settings_test_keys.py` mirrors `scripts/migrate_to_supabase.py`: dry-run is the default, `--execute` opts in, connects via `db.admin_transaction()` (service_role/owner, RLS-bypassing), one transaction. Pure helpers `find_test_keys()` / `clean_settings()` are module-level and unit-tested. **The destructive `--execute` against production is intentionally left as a manual step** (see PR body) — this PR ran only the dry-run.
+
+**Consequences.** `_handle_post_settings` strips `_` keys (the merge still treats `null` as delete for legit keys). The sweep removes only `_`-prefixed keys; OAuth tokens, branding, volunteer roles are preserved byte-identically. c4 (post-sweep prod state) and c5 (live-lane byte-identical row) are manual — they require executing against / running the lane against production.
+
+---
+
 ## 2026-06-08 — next-week-offering: per-project opt-* gate, first-line cause rule, offering decoupled from volunteer checkbox
 
 **Context.** Visalia CRC's bulletin OFFERING text comes from the selected week's PCO note; the "next week's offering is for X" line was typed by hand. Automate it: on import + re-sync, pull the next plan's OFFERING note and append the line to this week's OFFERING item.

--- a/docs/ai/project-state.md
+++ b/docs/ai/project-state.md
@@ -1,8 +1,17 @@
 # Project State
 
-_Last updated: 2026-06-10 (e2e-live lane triaged + fixed: first-ever green CI run)_
+_Last updated: 2026-06-11 (issue #299 — e2e settings pollution sweep + prevention guard, verified)_
 
-## Latest: nightly E2E Live lane fixed (2026-06-10, branch `fix/e2e-live-pco-refresh-creds`)
+## Latest: #299 e2e settings pollution swept (dry-run) + recurrence prevented (2026-06-11, branch `fix/issue-299-e2e-settings-pollution-sweep`)
+
+E2E runs that signed in to the production Visalia CRC workspace had merged `_testKey`/`_screenshots` into its `workspace_settings` row via the merge-style `POST /api/settings`. Two safeguards landed (verification-gate PASS):
+
+1. **Prevention (server-side guard).** `server.py` `_strip_reserved_settings_keys()` (pure) is applied in `_handle_post_settings` before the merge — any `_`-prefixed key (reserved test namespace) is dropped, so no client/spec write can persist a test key into `workspace_settings` again. Backed by the live-lane read-only convention now documented in `tests/e2e/README.md` + a comment on the `live` Playwright project.
+2. **Cleanup (sweep script).** `scripts/sweep_settings_test_keys.py` — dry-run-by-default (mirrors `migrate_to_supabase.py`), `--execute` opts in, connects via `db.admin_transaction()`. **DRY-RUN captured (read-only):** workspace `614505d2-0f12-4c00-afb1-9077a0dc94fe` holds exactly `_screenshots` + `_testKey`; "Would remove 2 stray key(s) across 1 workspace(s)."
+
+**Verification PASS:** contract tests `tests/contract/test_issue_299.py` 7 passed (red→green), `checks --level pr` PASS (173 pytest CI subset, 133 vitest/1 skipped, vite build). Contract `docs/ai/contracts/issue-299.json` — c1–c3 automated/green, c4 (post-sweep prod `jsonb_object_keys` clean) + c5 (live-lane byte-identical row) are manual. **🟡 The destructive `--execute` was NOT run against production** (task CAUTION) — it is a documented manual step in the draft PR. Run `APP_MODE=server python scripts/sweep_settings_test_keys.py --execute` (from repo root, `.env` loaded) to actually remove the 2 keys, then re-check c4/c5. #299 stays OPEN until execution.
+
+## Earlier: nightly E2E Live lane fixed (2026-06-10, branch `fix/e2e-live-pco-refresh-creds`)
 
 The scheduled `e2e-live.yml` lane had NEVER passed in CI (4/4 failures June 7–10). Two stacked root causes, both fixed:
 
@@ -117,6 +126,7 @@ The Playwright E2E suite (core lane) now runs as a PR gate on every PR (`e2e-cor
 
 ## Next step
 
+0. **#299 — execute the production sweep (MANUAL, destructive).** The draft PR for `fix/issue-299-e2e-settings-pollution-sweep` is open with the sweep script + prevention guard verified. Dry-run confirms 2 stray keys in the Visalia CRC row. To finish: from the repo root with `.env` loaded, run `APP_MODE=server python scripts/sweep_settings_test_keys.py --execute`, then verify c4 (`SELECT jsonb_object_keys(settings)` shows no `_` keys) and optionally c5 (workflow_dispatch e2e-live.yml, diff the row). Then close #299. The PR is intentionally non-closing until then.
 1. **Open draft PR** for `feat/desktop-anon-key-rls` (covers #224, #225, #279, #280, #294 and all prior work on this branch). Update PR #293 description to include #294.
 2. **Manual smoke handoff for #279/#280/#294** — trigger a build, crash the app, relaunch; confirm (a) stale-sidecar reap clears port without "Exit code 1" dialog, (b) cold-start is noticeably faster with onedir, (c) PCO import and Google Calendar work in the packaged Electron build (requires `SUPABASE_URL` + `SUPABASE_ANON_KEY` bundled and a Supabase JWT forwarded from renderer).
 3. **277-F** — after PR #293 merged + Electron smoke passes: remove `DATABASE_URL` from `release-electron.yml`, flip `APP_MODE=electron` in the Electron sidecar spawn, verify sidecar boots cleanly without DATABASE_URL. This closes the 🔴 extractable-creds risk.
@@ -126,6 +136,23 @@ The Playwright E2E suite (core lane) now runs as a PR gate on every PR (`e2e-cor
    - Data migration dry-run: `python scripts/migrate_to_supabase.py --source /Volumes/docker/bulletingenerator/app/data`
 
 ## Recent coding-agent runs
+
+### 2026-06-11 — issue #299 e2e settings pollution sweep + prevention (branch `fix/issue-299-e2e-settings-pollution-sweep`)
+- Files modified:
+  - `server.py` — new pure helpers `_is_reserved_settings_key` / `_strip_reserved_settings_keys` (after `_save_settings`); `_handle_post_settings` now strips `_`-prefixed reserved keys before the merge so no e2e write can persist a test key into `workspace_settings`.
+  - `scripts/sweep_settings_test_keys.py` — NEW. Dry-run-by-default sweep (mirrors `migrate_to_supabase.py`): pure `find_test_keys()` / `clean_settings()`, `sweep(execute)` over all `workspace_settings` rows via `db.admin_transaction()`; `--execute` writes the cleaned blob. Repo root pushed onto `sys.path` for the deferred `from db import`.
+  - `tests/contract/test_issue_299.py` — NEW. 7 contract tests (c1 prevention guard via real `_handle_post_settings`; c2 detection; c3 cleaning + dry-run no-mutate). Red-before-green confirmed (5 failed pre-impl).
+  - `docs/ai/contracts/issue-299.json` — acceptance contract (5 criteria: 3 unit, c4/c5 manual).
+  - `tests/e2e/README.md` — NEW. Documents the live-lane read-only convention + the #299 prevention/cleanup safeguards.
+  - `playwright.config.ts` — comment on the `live` project pointing at the read-only convention.
+  - `.github/workflows/ci.yml` + `scripts/run_ai_workflow.py` — wired `tests/contract/test_issue_299.py` into the `python` CI job + `CI_PYTEST_TARGETS`.
+- Checks run:
+  - Contract tests: `APP_MODE=server .venv/bin/python -m pytest tests/contract/test_issue_299.py -v` → 7 passed (5 failed pre-impl).
+  - `scripts/run_ai_workflow.py checks --level pr` → PASS (173 pytest CI subset, 133 vitest/1 skipped, vite build).
+  - **DRY-RUN against production** (read-only): workspace `614505d2-0f12-4c00-afb1-9077a0dc94fe` has exactly `_screenshots`, `_testKey`; "Would remove 2 stray key(s) across 1 workspace(s)." No writes performed.
+- Decisions made: `_`-prefix = reserved test namespace; prevention is a server-side strip (defense-in-depth) + read-only convention; cleanup is a dry-run-default script. See `docs/ai/decisions.md` 2026-06-11.
+- Deviations from spec: none. Contract test lives in `tests/contract/` (acceptance-contract default) — repo had no prior `tests/contract/` dir; pytest collects it fine.
+- Concerns: **The destructive `--execute` was NOT run against production** (task CAUTION) — left as a manual PR step. c4 (post-sweep prod `jsonb_object_keys` clean) and c5 (live-lane byte-identical row) are manual, require executing/running against prod.
 
 ### 2026-06-08 — next-week-offering follow-ups (branch `fix/next-week-offering`)
 - **Import-path stale-ref fix (commit `1643bcd`):** `pcoFetchAndApplyNextWeekOffering` captured the OFFERING item ref before its `await pcoGet` calls; the import flow replaces `items[]` during the awaits → orphaned ref → line dropped on fresh import (only appeared after a re-sync). Fixed: cheap `items.some()` presence check up front, then re-find the live OFFERING item after the awaits before mutating. **User-confirmed PASS on live import.**

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -48,6 +48,13 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'], storageState: 'tests/e2e/.auth/core.json' },
     },
     {
+      // @live specs run against the REAL production workspace (signed in as
+      // e2e-live@e2e.bulletin.test, a viewer in Visalia CRC). They MUST be
+      // read-only: never import a plan, never persist settings/projects.
+      // /api/settings is merge-style, so any settings write lands in the
+      // production row. The server strips _-prefixed keys defensively
+      // (issue #299), but the convention is "live specs touch no production
+      // data". See tests/e2e/README.md.
       name: 'live',
       grep: /@live/,
       dependencies: ['live-setup'],

--- a/scripts/run_ai_workflow.py
+++ b/scripts/run_ai_workflow.py
@@ -34,6 +34,7 @@ CI_PYTEST_TARGETS = [
     "tests/test_revision_snapshots.py",
     "tests/test_port_bind.py",
     "tests/test_supabase_rest_settings.py",
+    "tests/contract/test_issue_299.py",
 ]
 
 MANUAL_SMOKE_DOC = "docs/testing/manual-smoke.md"

--- a/scripts/sweep_settings_test_keys.py
+++ b/scripts/sweep_settings_test_keys.py
@@ -1,0 +1,184 @@
+"""
+scripts/sweep_settings_test_keys.py — Sweep e2e test pollution from
+``workspace_settings`` (issue #299).
+
+E2E runs that signed in to a real workspace (the live lane uses
+``e2e-live@e2e.bulletin.test``, a viewer in the production Visalia CRC
+workspace) historically wrote test-only keys — ``_testKey``, ``_screenshots``,
+and any other ``_``-prefixed key — into the production ``workspace_settings``
+row via the merge-style ``POST /api/settings``. The ``_`` prefix is a reserved
+test namespace the product never uses, so any ``_``-prefixed key in
+``workspace_settings.settings`` is stray pollution.
+
+This script finds and removes those keys. **Dry-run is the DEFAULT** — it lists
+exactly what it would delete and writes nothing. ``--execute`` is an explicit
+opt-in that writes the cleaned settings blob back via the RLS-bypassing admin
+connection.
+
+The companion server-side guard (``server.py`` ``_strip_reserved_settings_keys``
+applied in ``_handle_post_settings``) prevents *recurrence*; this script cleans
+up rows already polluted before that guard landed.
+
+Usage::
+
+    # Dry-run (default — no DB writes): list stray test keys per workspace
+    APP_MODE=server python scripts/sweep_settings_test_keys.py
+
+    # Execute (writes the cleaned blob back):
+    APP_MODE=server python scripts/sweep_settings_test_keys.py --execute
+
+Environment variables (for both modes — a connection is needed even to read):
+    SUPABASE_SERVICE_ROLE_URL  — preferred (service_role bypasses RLS)
+    DATABASE_URL               — fallback (DB-owner credentials)
+    APP_MODE=server            — required by db.py
+
+Data-safety rules:
+    * Dry-run is the DEFAULT; --execute is an explicit opt-in.
+    * The service_role / DATABASE_URL string is never logged.
+    * Only ``_``-prefixed keys are removed; every other key is preserved
+      byte-identically (OAuth tokens, branding, volunteer roles, etc.).
+    * The whole run is one transaction (admin_transaction): all-or-nothing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers (no DB) — unit-tested by tests/contract/test_issue_299.py
+# ---------------------------------------------------------------------------
+
+def _is_test_key(key) -> bool:
+    """True if *key* is a reserved (``_``-prefixed) test-only key."""
+    return isinstance(key, str) and key.startswith("_")
+
+
+def find_test_keys(settings: dict) -> list[str]:
+    """Return the sorted list of ``_``-prefixed keys present in *settings*.
+
+    These are the keys the sweep would delete. An empty list means the row is
+    already clean."""
+    if not isinstance(settings, dict):
+        return []
+    return sorted(k for k in settings if _is_test_key(k))
+
+
+def clean_settings(settings: dict) -> dict:
+    """Return a NEW dict with every ``_``-prefixed key removed.
+
+    Pure — does not mutate *settings* (so dry-run can safely call it). Every
+    non-test key is preserved unchanged."""
+    if not isinstance(settings, dict):
+        return settings
+    return {k: v for k, v in settings.items() if not _is_test_key(k)}
+
+
+# ---------------------------------------------------------------------------
+# DB sweep
+# ---------------------------------------------------------------------------
+
+def sweep(execute: bool = False) -> int:
+    """Scan ``workspace_settings`` for stray test keys.
+
+    Dry-run (default): print what would be deleted, write nothing.
+    Execute: write the cleaned settings blob back for each polluted row.
+
+    Returns a process exit code (0 = success / nothing to do)."""
+    # Deferred import so the module (and its pure helpers) can be imported
+    # without a DB connection — the contract tests rely on this.
+    import os.path  # noqa: PLC0415
+    _repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    if _repo_root not in sys.path:
+        sys.path.insert(0, _repo_root)
+    try:
+        from db import admin_transaction, from_jsonb  # type: ignore[import]
+    except Exception as exc:  # pragma: no cover - import-environment guard
+        sys.stderr.write(
+            f"ERROR: cannot import from db.py: {exc}\n"
+            "Set APP_MODE=server and ensure SUPABASE_SERVICE_ROLE_URL or "
+            "DATABASE_URL is set.\n"
+        )
+        return 2
+
+    import json  # noqa: PLC0415
+
+    mode = "EXECUTE" if execute else "DRY RUN"
+    print(f"=== sweep_settings_test_keys.py  [{mode}] ===")
+
+    polluted = 0
+    total_keys = 0
+    try:
+        with admin_transaction() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT workspace_id, settings FROM public.workspace_settings"
+                )
+                rows = cur.fetchall()
+
+                for workspace_id, settings_raw in rows:
+                    settings = from_jsonb(settings_raw) or {}
+                    stray = find_test_keys(settings)
+                    if not stray:
+                        continue
+                    polluted += 1
+                    total_keys += len(stray)
+                    print(f"\nworkspace {workspace_id}:")
+                    print(f"  stray test keys ({len(stray)}): {', '.join(stray)}")
+                    if execute:
+                        cleaned = clean_settings(settings)
+                        cur.execute(
+                            "UPDATE public.workspace_settings "
+                            "SET settings = %s::jsonb WHERE workspace_id = %s",
+                            (json.dumps(cleaned), workspace_id),
+                        )
+                        print(f"  -> removed {len(stray)} key(s)")
+            # admin_transaction commits on clean exit; on dry-run nothing was written.
+    except Exception as exc:
+        sys.stderr.write(f"ERROR: sweep failed: {exc}\n")
+        return 1
+
+    print()
+    if polluted == 0:
+        print("No stray _-prefixed test keys found. workspace_settings is clean.")
+    elif execute:
+        print(f"Removed {total_keys} stray key(s) across {polluted} workspace(s).")
+    else:
+        print(
+            f"Would remove {total_keys} stray key(s) across {polluted} workspace(s)."
+        )
+        print("  Re-run with --execute to write the cleaned settings back.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Sweep stray _-prefixed e2e test keys from workspace_settings "
+            "(issue #299). Dry-run is the DEFAULT; pass --execute to write."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--dry-run",
+        dest="execute",
+        action="store_false",
+        default=False,
+        help="List stray test keys without writing (the default).",
+    )
+    parser.add_argument(
+        "--execute",
+        dest="execute",
+        action="store_true",
+        help=(
+            "Write the cleaned settings blob back via admin_transaction(). "
+            "Requires SUPABASE_SERVICE_ROLE_URL (or DATABASE_URL) and APP_MODE=server."
+        ),
+    )
+    args = parser.parse_args(argv)
+    sys.exit(sweep(execute=args.execute))
+
+
+if __name__ == "__main__":
+    main()

--- a/server.py
+++ b/server.py
@@ -424,6 +424,26 @@ def _save_settings(data: dict, storage=None) -> dict:
     return (storage or get_storage(DATA_DIR)).save_settings(data)
 
 
+# The ``_`` prefix is a reserved namespace in workspace_settings: it is used
+# only by e2e/test scaffolding (e.g. ``_testKey``, ``_screenshots``), never by
+# the product. Client settings writes that carry such keys must never persist
+# them — otherwise an e2e run signed in to a real workspace pollutes the
+# production settings row (issue #299). The sweep script
+# (scripts/sweep_settings_test_keys.py) cleans up rows already polluted by
+# pre-guard runs; this guard prevents recurrence.
+def _is_reserved_settings_key(key) -> bool:
+    """True if *key* belongs to the reserved (``_``-prefixed) test namespace."""
+    return isinstance(key, str) and key.startswith("_")
+
+
+def _strip_reserved_settings_keys(partial: dict) -> dict:
+    """Return *partial* with any reserved (``_``-prefixed) keys removed.
+
+    Pure (does not mutate the input). Applied to inbound /api/settings writes
+    so test-only keys can never reach workspace_settings."""
+    return {k: v for k, v in partial.items() if not _is_reserved_settings_key(k)}
+
+
 class _SupabaseRestSettings:
     """Read/write ``workspace_settings`` via the Supabase REST API using the
     caller's JWT + the publishable anon key.
@@ -2132,6 +2152,9 @@ class Handler(http.server.SimpleHTTPRequestHandler):
             self._send_json({"error": "body must be an object"}, 400)
             return
         store = self._storage_for_user(user)
+        # Reserved (_-prefixed) keys are a test-only namespace and must never
+        # persist into workspace_settings (issue #299). Strip them before merge.
+        partial = _strip_reserved_settings_keys(partial)
         # Merge the partial update with existing settings.
         existing = store.get_settings()
         for key, value in partial.items():

--- a/tests/contract/test_issue_299.py
+++ b/tests/contract/test_issue_299.py
@@ -1,0 +1,197 @@
+"""Contract tests for issue #299 — sweep e2e test pollution (_testKey,
+_screenshots) from production workspace_settings + prevent recurrence.
+
+These tests encode the issue's acceptance criteria as executable assertions.
+They MUST fail on the unmodified codebase and pass once the implementation
+lands. No live database, network, or HTTP server is required — the prevention
+guard is exercised through the real ``_handle_post_settings`` Handler method
+(network methods mocked), and the sweep logic is exercised through the pure
+helpers the sweep script exposes.
+
+Mapping to acceptance criteria:
+  c1 — prevention: a settings POST carrying ``_``-prefixed keys must NOT
+       persist those keys (reserved namespace stripped server-side).
+  c2 — sweep detection: the sweep identifies exactly the ``_``-prefixed keys
+       in a settings blob and leaves legitimate keys alone.
+  c3 — sweep cleaning: cleaning a blob removes every ``_``-prefixed key while
+       preserving all other keys byte-identically; dry-run does not mutate.
+  c4 — (manual) production row shows no ``_``-prefixed keys after the sweep
+       executes.
+  c5 — (manual) a full live-lane run leaves the production settings row
+       byte-identical (excluding refreshed OAuth tokens).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import types
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+# Python 3.13+ removed the stdlib ``cgi`` module that server.py imports lazily.
+if "cgi" not in sys.modules:
+    sys.modules["cgi"] = types.ModuleType("cgi")
+
+import server  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Handler test harness (mirrors tests/test_collab_regression.py)
+# ---------------------------------------------------------------------------
+
+def _mock_user(email: str = "e2e-live@e2e.bulletin.test") -> dict:
+    return {
+        "id": "00000000-0000-0000-0000-000000000299",
+        "email": email,
+        "display_name": "E2E Live",
+        "avatar_url": "",
+        "domain": email.split("@")[-1],
+        "workspace_id": "614505d2-0f12-4c00-afb1-9077a0dc94fe",
+    }
+
+
+def _make_handler(path: str, body: bytes = b"") -> server.Handler:
+    handler = server.Handler.__new__(server.Handler)
+    handler._send_json = MagicMock()
+    handler.send_response = MagicMock()
+    handler.send_header = MagicMock()
+    handler.end_headers = MagicMock()
+    handler.wfile = MagicMock()
+    handler.server = MagicMock()
+    handler.server.server_address = ("127.0.0.1", 8080)
+    handler.path = path
+    handler.headers = {
+        "Cookie": "bg_session=tok",
+        "Content-Length": str(len(body)),
+        "Content-Type": "application/json",
+    }
+    handler.rfile = BytesIO(body)
+    return handler
+
+
+def _post_settings(partial: dict, existing: dict | None = None) -> dict:
+    """Drive the real _handle_post_settings and return the dict that was
+    actually persisted (the argument passed to store.save_settings)."""
+    body = json.dumps(partial).encode()
+    handler = _make_handler("/api/settings", body=body)
+    mock_store = MagicMock()
+    mock_store.get_settings.return_value = dict(existing or {})
+    with patch.object(server, "IS_DESKTOP", False), \
+         patch("auth.get_request_user", return_value=_mock_user()), \
+         patch("storage.get_storage", return_value=mock_store):
+        handler._handle_post_settings()
+    assert mock_store.save_settings.called, "save_settings was never called"
+    return mock_store.save_settings.call_args[0][0]
+
+
+# ---------------------------------------------------------------------------
+# Sweep script loader (script lives outside the importable package tree)
+# ---------------------------------------------------------------------------
+
+def _load_sweep_module():
+    path = REPO_ROOT / "scripts" / "sweep_settings_test_keys.py"
+    if not path.exists():
+        pytest.fail(
+            f"UNVERIFIED: sweep script not found at {path} — "
+            "expected scripts/sweep_settings_test_keys.py"
+        )
+    spec = importlib.util.spec_from_file_location("sweep_settings_test_keys", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ===========================================================================
+# c1 — Prevention guard (unit)
+# ===========================================================================
+
+class TestPreventionGuard:
+    def test_underscore_keys_are_not_persisted(self):
+        """issue-299-c1: a settings POST carrying _testKey/_screenshots must
+        not persist those keys into workspace_settings."""
+        persisted = _post_settings(
+            {"_testKey": "boom", "_screenshots": ["a.png"], "churchName": "Visalia CRC"}
+        )
+        assert "_testKey" not in persisted, "_testKey leaked into persisted settings"
+        assert "_screenshots" not in persisted, "_screenshots leaked into persisted settings"
+
+    def test_legitimate_keys_still_persist(self):
+        """issue-299-c1: the guard must not disturb normal settings writes."""
+        persisted = _post_settings({"churchName": "Visalia CRC", "docTemplate": "letter"})
+        assert persisted.get("churchName") == "Visalia CRC"
+        assert persisted.get("docTemplate") == "letter"
+
+    def test_guard_does_not_strip_existing_legit_keys(self):
+        """issue-299-c1: merging a clean partial must preserve prior keys."""
+        persisted = _post_settings(
+            {"docTemplate": "a4"}, existing={"churchName": "Visalia CRC"}
+        )
+        assert persisted.get("churchName") == "Visalia CRC"
+        assert persisted.get("docTemplate") == "a4"
+
+
+# ===========================================================================
+# c2 — Sweep detection (unit)
+# ===========================================================================
+
+class TestSweepDetection:
+    def test_finds_underscore_prefixed_keys(self):
+        """issue-299-c2: the sweep identifies exactly the _-prefixed keys."""
+        mod = _load_sweep_module()
+        settings = {
+            "_testKey": 1,
+            "_screenshots": [],
+            "churchName": "Visalia CRC",
+            "pcoAccessToken": "tok",
+        }
+        found = set(mod.find_test_keys(settings))
+        assert found == {"_testKey", "_screenshots"}
+
+    def test_empty_when_no_test_keys(self):
+        """issue-299-c2: a clean blob yields no keys to delete."""
+        mod = _load_sweep_module()
+        assert mod.find_test_keys({"churchName": "x", "docTemplate": "letter"}) == []
+
+
+# ===========================================================================
+# c3 — Sweep cleaning + dry-run safety (unit)
+# ===========================================================================
+
+class TestSweepCleaning:
+    def test_clean_removes_only_underscore_keys(self):
+        """issue-299-c3: cleaning removes _-prefixed keys, preserves the rest."""
+        mod = _load_sweep_module()
+        before = {
+            "_testKey": 1,
+            "_screenshots": ["a.png"],
+            "churchName": "Visalia CRC",
+            "pcoAccessToken": "tok",
+            "volunteerRoles": [{"id": "r1"}],
+        }
+        cleaned = mod.clean_settings(before)
+        assert cleaned == {
+            "churchName": "Visalia CRC",
+            "pcoAccessToken": "tok",
+            "volunteerRoles": [{"id": "r1"}],
+        }
+
+    def test_clean_does_not_mutate_input(self):
+        """issue-299-c3: dry-run safety — clean_settings must not mutate its arg."""
+        mod = _load_sweep_module()
+        before = {"_testKey": 1, "churchName": "Visalia CRC"}
+        snapshot = json.loads(json.dumps(before))
+        mod.clean_settings(before)
+        assert before == snapshot, "clean_settings mutated its input"
+
+
+# ===========================================================================
+# c4, c5 — manual (recorded in contract.json; no executable test)
+# ===========================================================================

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,51 @@
+# E2E tests (Playwright)
+
+Two lanes, selected by tag and Playwright project:
+
+| Lane | Tag | Project | Auth | Data |
+|------|-----|---------|------|------|
+| **core** (PR gate) | `@core` | `core` | ephemeral throwaway identity (created/swept per run) | a fresh, isolated workspace — safe to write |
+| **live** (nightly) | `@live` | `live` | `e2e-live@e2e.bulletin.test`, a **viewer in the real Visalia CRC workspace** | the **production** workspace — must NOT be mutated |
+
+## Live-lane read-only convention (non-negotiable)
+
+`@live` specs exercise the real Planning Center / Google integrations using
+tokens that live in the production workspace. Because the live member is signed
+in to that real workspace, **any write the test performs lands in production
+data.**
+
+Therefore `@live` specs MUST be read-only:
+
+- Never click Import on a PCO plan.
+- Never persist a project (no Save, and remember autosave fires once a project
+  is active).
+- Never write settings. `POST /api/settings` is **merge-style**, so even a
+  single field write merges into the production `workspace_settings` row.
+- Read-only assertions only: dropdowns populate, the import view is visible,
+  proxied data loads, etc.
+
+If a `@live` spec genuinely needs to verify a write path, it must run in the
+`core` lane against its isolated ephemeral workspace instead, or clean up after
+itself in teardown (null the key it wrote).
+
+## Defense in depth (issue #299)
+
+E2E runs once polluted the production `workspace_settings` row with
+`_testKey` / `_screenshots`. Two safeguards now exist:
+
+1. **Prevention (server-side).** `server.py` `_handle_post_settings` strips any
+   `_`-prefixed key before merging — the `_` prefix is a reserved test-only
+   namespace, so a stray test write can no longer persist into
+   `workspace_settings`. See `server.py` `_strip_reserved_settings_keys`.
+2. **Cleanup (script).** `scripts/sweep_settings_test_keys.py` removes existing
+   `_`-prefixed pollution. Dry-run is the default; `--execute` writes:
+
+   ```bash
+   # list what would be removed (no writes):
+   APP_MODE=server python scripts/sweep_settings_test_keys.py
+   # actually remove it:
+   APP_MODE=server python scripts/sweep_settings_test_keys.py --execute
+   ```
+
+The convention above is still the primary rule — the server guard is a backstop,
+not a license to write from `@live` specs.


### PR DESCRIPTION
## Issue #299 — sweep e2e test pollution from production `workspace_settings` + prevent recurrence

E2E runs that sign in to the **production** Visalia CRC workspace (the nightly `@live` lane uses `e2e-live@e2e.bulletin.test`, a viewer in that real workspace) had merged `_testKey` / `_screenshots` into its `workspace_settings` row via the merge-style `POST /api/settings`. This PR delivers both halves of #299.

### 1. Prevention (recurrence) — server-side guard
- `server.py`: new pure `_is_reserved_settings_key()` / `_strip_reserved_settings_keys()` helpers, applied in `_handle_post_settings` **before** the merge. The `_` prefix is a reserved test-only namespace (the product uses no `_`-prefixed top-level settings key), so any such key is dropped and can never persist into `workspace_settings` again — regardless of which client or spec sends it.
- `tests/e2e/README.md` (new) + a comment on the `live` Playwright project document the **live-lane read-only convention** (the primary rule; the server guard is defense-in-depth).

### 2. Cleanup — reviewable sweep script (dry-run by default)
- `scripts/sweep_settings_test_keys.py` (new): mirrors `scripts/migrate_to_supabase.py` — **dry-run is the default**, `--execute` is an explicit opt-in, connects via `db.admin_transaction()` (service_role/owner, one transaction). Pure helpers `find_test_keys()` / `clean_settings()` remove only `_`-prefixed keys; OAuth tokens, branding, and volunteer roles are preserved byte-identically.

### Dry-run evidence (read-only — captured, no writes)
```
=== sweep_settings_test_keys.py  [DRY RUN] ===

workspace 614505d2-0f12-4c00-afb1-9077a0dc94fe:
  stray test keys (2): _screenshots, _testKey

Would remove 2 stray key(s) across 1 workspace(s).
  Re-run with --execute to write the cleaned settings back.
```
Exactly the two keys named in the issue, in the production Visalia CRC workspace, and no others.

### Verification
- Contract `docs/ai/contracts/issue-299.json` + `tests/contract/test_issue_299.py` — **7 tests, red→green** (c1 prevention guard via the real `_handle_post_settings`; c2 detection; c3 cleaning + dry-run no-mutate).
- `scripts/run_ai_workflow.py checks --level pr` → **PASS** (173 pytest CI subset, 133 vitest / 1 skipped, vite build green).
- Contract test wired into the CI `python` job + `CI_PYTEST_TARGETS`.

### ⚠️ MANUAL STEP — production sweep execution (intentionally not run here)
This PR touches production Supabase data, so per safety policy **only the dry-run was executed.** To complete the cleanup, a human runs, from the repo root with `.env` loaded:
```bash
APP_MODE=server python scripts/sweep_settings_test_keys.py --execute
```
Then verify the acceptance criteria:
- **c4** — `SELECT jsonb_object_keys(settings) FROM workspace_settings` shows no `_`-prefixed keys.
- **c5** — a full `workflow_dispatch` of `e2e-live.yml` leaves the row byte-identical (excluding refreshed OAuth tokens).

### Deferred — still open
- **#299** — sweep script + prevention guard are ready and verified; the destructive `--execute` against production is **pending human** (see the manual step above). Do not auto-close; close #299 only after a human runs `--execute` and confirms c4/c5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)